### PR TITLE
BGRA GlInternalFormat

### DIFF
--- a/BCnEnc.Net/Decoder/BcDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcDecoder.cs
@@ -694,7 +694,9 @@ namespace BCnEncoder.Decoder
 				case GlInternalFormat.GlRgba8:
 					return CompressionFormat.Rgba;
 
-				// HINT: Bgra has no internal format to convert from
+				// HINT: Bgra is only an extension by apple to the ktx format
+				case GlInternalFormat.GlBgra8Extension:
+					return CompressionFormat.Bgra;
 
 				case GlInternalFormat.GlCompressedRgbS3TcDxt1Ext:
 					return CompressionFormat.Bc1;

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -225,7 +225,7 @@ namespace BCnEncoder.Encoder
 
 		public GlInternalFormat GetInternalFormat()
 		{
-			throw new NotImplementedException();
+			return GlInternalFormat.GlBgra8Extension;
 		}
 
 		public GlFormat GetBaseInternalFormat()

--- a/BCnEnc.Net/Shared/GLFormat.cs
+++ b/BCnEnc.Net/Shared/GLFormat.cs
@@ -162,6 +162,9 @@ namespace BCnEncoder.Shared
 		GlCompressedRgba8Etc2Eac = 0x9278,
 		GlCompressedSrgb8Alpha8Etc2Eac = 0x9279,
 
+		// Apple extension BGRA8
+		GlBgra8Extension = 0x93A1,
+
 		// ASTC
 		GlCompressedRgbaAstc4X4Khr = 0x93B0,
 		GlCompressedRgbaAstc5X4Khr = 0x93B1,


### PR DESCRIPTION
As per issue #26 this adds the extension enum value to GlInternalFormat by apple for BGRA8.
It was added to both BcEncoder and BcDecoder as well.