### PR TITLE
Remove ImageSharp dependency completely

### DIFF
--- a/BCnEnc.Net/BCnEncoder.csproj
+++ b/BCnEnc.Net/BCnEncoder.csproj
@@ -45,7 +45,6 @@ Supported formats are:
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.0.0-preview4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/BCnEnc.Net/Decoder/RawDecoder.cs
+++ b/BCnEnc.Net/Decoder/RawDecoder.cs
@@ -1,4 +1,3 @@
-using SixLabors.ImageSharp.PixelFormats;
 using System;
 using BCnEncoder.Shared;
 
@@ -6,7 +5,7 @@ namespace BCnEncoder.Decoder
 {
 	internal interface IRawDecoder
 	{
-		Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context);
+		ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context);
 	}
 
 	/// <summary>
@@ -29,13 +28,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -46,18 +43,18 @@ namespace BCnEncoder.Decoder
 
 				if (redAsLuminance)
 				{
-					output[i].R = span[i];
-					output[i].G = span[i];
-					output[i].B = span[i];
+					output[i].r = span[i];
+					output[i].g = span[i];
+					output[i].b = span[i];
 				}
 				else
 				{
-					output[i].R = span[i];
-					output[i].G = 0;
-					output[i].B = 0;
+					output[i].r = span[i];
+					output[i].g = 0;
+					output[i].b = 0;
 				}
 
-				output[i].A = 255;
+				output[i].a = 255;
 			}
 
 			return output;
@@ -73,13 +70,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 2];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -88,10 +83,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].R = span[i * 2];
-				output[i].G = span[i * 2 + 1];
-				output[i].B = 0;
-				output[i].A = 255;
+				output[i].r = span[i * 2];
+				output[i].g = span[i * 2 + 1];
+				output[i].b = 0;
+				output[i].a = 255;
 			}
 
 			return output;
@@ -107,13 +102,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 3];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -122,10 +115,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].R = span[i * 3];
-				output[i].G = span[i * 3 + 1];
-				output[i].B = span[i * 3 + 2];
-				output[i].A = 255;
+				output[i].r = span[i * 3];
+				output[i].g = span[i * 3 + 1];
+				output[i].b = span[i * 3 + 2];
+				output[i].a = 255;
 			}
 
 			return output;
@@ -141,13 +134,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 4];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -156,10 +147,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].R = span[i * 4];
-				output[i].G = span[i * 4 + 1];
-				output[i].B = span[i * 4 + 2];
-				output[i].A = span[i * 4 + 3];
+				output[i].r = span[i * 4];
+				output[i].g = span[i * 4 + 1];
+				output[i].b = span[i * 4 + 2];
+				output[i].a = span[i * 4 + 3];
 			}
 
 			return output;
@@ -175,13 +166,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 4];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -190,10 +179,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].B = span[i * 4];
-				output[i].G = span[i * 4 + 1];
-				output[i].R = span[i * 4 + 2];
-				output[i].A = span[i * 4 + 3];
+				output[i].b = span[i * 4];
+				output[i].g = span[i * 4 + 1];
+				output[i].r = span[i * 4 + 2];
+				output[i].a = span[i * 4 + 3];
 			}
 
 			return output;

--- a/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
@@ -1,4 +1,5 @@
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
@@ -69,7 +69,7 @@ namespace BCnEncoder.Encoder
 			var bc2AlphaBlock = new Bc2AlphaBlock();
 			for (var i = 0; i < 16; i++)
 			{
-				bc2AlphaBlock.SetAlpha(i, block[i].A);
+				bc2AlphaBlock.SetAlpha(i, block[i].a);
 			}
 
 			return new AtcExplicitAlphaBlock

--- a/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc1BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc1BlockEncoder.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
@@ -62,7 +62,7 @@ namespace BCnEncoder.Encoder
 			for (var i = 0; i < 16; i++)
 			{
 				var color = pixels[i];
-				output.SetAlpha(i, color.A);
+				output.SetAlpha(i, color.a);
 				output[i] = ColorChooser.ChooseClosestColor4(colors, color, rWeight, gWeight, bWeight, out var e);
 				error += e;
 			}

--- a/BCnEnc.Net/Encoder/Bc3BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc3BlockEncoder.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
@@ -69,19 +69,19 @@ namespace BCnEncoder.Encoder
 				switch (component)
 				{
 					case Bc4Component.R:
-						colors[i] = pixels[i].R;
+						colors[i] = pixels[i].r;
 						break;
 
 					case Bc4Component.G:
-						colors[i] = pixels[i].G;
+						colors[i] = pixels[i].g;
 						break;
 
 					case Bc4Component.B:
-						colors[i] = pixels[i].B;
+						colors[i] = pixels[i].b;
 						break;
 
 					case Bc4Component.A:
-						colors[i] = pixels[i].A;
+						colors[i] = pixels[i].a;
 						break;
 
 					case Bc4Component.Luminance:

--- a/BCnEnc.Net/Encoder/Bc5BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc5BlockEncoder.cs
@@ -1,4 +1,5 @@
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
+++ b/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder.Bc7
 {

--- a/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
+++ b/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
 

--- a/BCnEnc.Net/Encoder/Bc7/Bc7EncodingHelpers.cs
+++ b/BCnEnc.Net/Encoder/Bc7/Bc7EncodingHelpers.cs
@@ -1,8 +1,7 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using BCnEncoder.Shared;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder.Bc7
 {
@@ -636,7 +635,7 @@ namespace BCnEncoder.Encoder.Bc7
 				}
 			}
 
-			Span<Rgba32> subsetColors = stackalloc Rgba32[count];
+			Span<ColorRgba32> subsetColors = stackalloc ColorRgba32[count];
 			var next = 0;
 			for (var i = 0; i < 16; i++)
 			{
@@ -827,7 +826,7 @@ namespace BCnEncoder.Encoder.Bc7
 					var pixelColor = new ColorYCbCr(pixels[i]);
 
 					FindClosestColorIndex(pixelColor, colors, out var ce);
-					FindClosestAlphaIndex(pixels[i].A, alphas, out var ae);
+					FindClosestAlphaIndex(pixels[i].a, alphas, out var ae);
 
 					error += ce + ae;
 				}
@@ -931,10 +930,10 @@ namespace BCnEncoder.Encoder.Bc7
 				{
 					var pixelColor = new ColorYCbCr(pixels[i]);
 
-					var index = FindClosestColorIndex(pixelColor, colors, out var e);
+					var index = FindClosestColorIndex(pixelColor, colors, out _);
 					colorIndicesToFill[i] = (byte)index;
 
-					index = FindClosestAlphaIndex(pixels[i].A, alphas, out var _);
+					index = FindClosestAlphaIndex(pixels[i].a, alphas, out _);
 					alphaIndicesToFill[i] = (byte)index;
 				}
 			}
@@ -1101,13 +1100,13 @@ namespace BCnEncoder.Encoder.Bc7
 				switch (rotation)
 				{
 					case 1:
-						output[i] = new Rgba32(c.A, c.G, c.B, c.R);
+						output[i] = new ColorRgba32(c.a, c.g, c.b, c.r);
 						break;
 					case 2:
-						output[i] = new Rgba32(c.R, c.A, c.B, c.G);
+						output[i] = new ColorRgba32(c.r, c.a, c.b, c.g);
 						break;
 					case 3:
-						output[i] = new Rgba32(c.R, c.G, c.A, c.B);
+						output[i] = new ColorRgba32(c.r, c.g, c.a, c.b);
 						break;
 				}
 			}

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using BCnEncoder.Encoder.Bc7;
 using BCnEncoder.Encoder.Options;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using Microsoft.Toolkit.HighPerformance.Memory;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -11,6 +11,7 @@ using BCnEncoder.Encoder.Bc7;
 using BCnEncoder.Encoder.Options;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
+using Microsoft.Toolkit.HighPerformance.Extensions;
 using Microsoft.Toolkit.HighPerformance.Memory;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -301,202 +302,54 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		public void EncodeToStream<T>(Memory<T> inputPixelsRgba, int width, int height, Stream outputStream) where T : unmanaged
+		public void EncodeToStream(Memory2D<ColorRgba32> input, Stream outputStream)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			EncodeToStreamInternal(bytes, width, height, outputStream, default);
+			EncodeToStreamInternal(input, outputStream, default);
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a Ktx file.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>The Ktx file containing the encoded image.</returns>
-		public KtxFile EncodeToKtx<T>(Memory<T> inputPixelsRgba, int width, int height) where T : unmanaged
+		public KtxFile EncodeToKtx(Memory2D<ColorRgba32> input)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToKtxInternal(bytes, width, height, default);
+			return EncodeToKtxInternal(input, default);
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a Dds file.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>The Dds file containing the encoded image.</returns>
-		public DdsFile EncodeToDds<T>(Memory<T> inputPixelsRgba, int width, int height) where T : unmanaged
+		public DdsFile EncodeToDds<T>(Memory2D<ColorRgba32> input)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToDdsInternal(bytes, width, height, default);
+			return EncodeToDdsInternal(input, default);
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a list of byte buffers.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>A list of raw encoded mipmap data.</returns>
-		public IList<byte[]> EncodeToRawBytes<T>(Memory<T> inputPixelsRgba, int width, int height) where T : unmanaged
+		public byte[][] EncodeToRawBytes(Memory2D<ColorRgba32> input)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToRawBytesInternal(bytes, width, height, default);
+			return EncodeToRawBytesInternal(input, default);
 		}
 
 		/// <summary>
 		/// Encodes a single mip level of the input image to a byte buffer.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <param name="mipLevel">The mipmap to encode.</param>
 		/// <param name="mipWidth">The width of the mipmap.</param>
 		/// <param name="mipHeight">The height of the mipmap.</param>
 		/// <returns>The raw encoded data.</returns>
-		public byte[] EncodeToRawBytes<T>(Memory<T> inputPixelsRgba, int width, int height, int mipLevel, out int mipWidth, out int mipHeight) where T : unmanaged
+		public byte[] EncodeToRawBytes(Memory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToRawBytesInternal(bytes, width, height, mipLevel, out mipWidth,
-				out mipHeight, default);
-		}
-
-
-
-		/// <summary>
-		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		public void EncodeToStream<T>(Memory2D<T> inputPixelsRgba, Stream outputStream) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			EncodeToStreamInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, outputStream, default);
-		}
-
-		/// <summary>
-		/// Encodes all mipmap levels into a Ktx file.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <returns>The Ktx file containing the encoded image.</returns>
-		public KtxFile EncodeToKtx<T>(Memory2D<T> inputPixelsRgba) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			return EncodeToKtxInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, default);
-		}
-
-		/// <summary>
-		/// Encodes all mipmap levels into a Dds file.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <returns>The Dds file containing the encoded image.</returns>
-		public DdsFile EncodeToDds<T>(Memory2D<T> inputPixelsRgba) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			return EncodeToDdsInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, default);
-		}
-
-		/// <summary>
-		/// Encodes all mipmap levels into a list of byte buffers.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <returns>A list of raw encoded mipmap data.</returns>
-		public IList<byte[]> EncodeToRawBytes<T>(Memory2D<T> inputPixelsRgba) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			return EncodeToRawBytesInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, default);
-		}
-
-		/// <summary>
-		/// Encodes a single mip level of the input image to a byte buffer.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <param name="mipLevel">The mipmap to encode.</param>
-		/// <param name="mipWidth">The width of the mipmap.</param>
-		/// <param name="mipHeight">The height of the mipmap.</param>
-		/// <returns>The raw encoded data.</returns>
-		public byte[] EncodeToRawBytes<T>(Memory2D<T> inputPixelsRgba, int mipLevel, out int mipWidth, out int mipHeight) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			
-			return EncodeToRawBytesInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, mipLevel, out mipWidth,
-				out mipHeight, default);
+			return EncodeToRawBytesInternal(input, mipLevel, out mipWidth, out mipHeight, default);
 		}
 
 		#endregion
@@ -533,408 +386,403 @@ namespace BCnEncoder.Encoder
 
 		#region Private
 
-		private void EncodeToStreamInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, Stream outputStream, CancellationToken token)
+		private void EncodeToStreamInternal(Memory<ColorRgba32> input, int width, int height, Stream outputStream, CancellationToken token)
+		{
+			EncodeToStreamInternal(input.AsMemory2D(width, height), outputStream, token);
+		}
+
+		private void EncodeToStreamInternal(Memory2D<ColorRgba32> input, Stream outputStream, CancellationToken token)
 		{
 			switch (OutputOptions.FileFormat)
 			{
 				case OutputFileFormat.Dds:
-					var dds = EncodeToDdsInternal(inputPixelsRgba, width, height, token);
+					var dds = EncodeToDdsInternal(input, token);
 					dds.Write(outputStream);
 					break;
 
 				case OutputFileFormat.Ktx:
-					var ktx = EncodeToKtxInternal(inputPixelsRgba, width, height, token);
+					var ktx = EncodeToKtxInternal(input, token);
 					ktx.Write(outputStream);
 					break;
 			}
 		}
 
-		private KtxFile EncodeToKtxInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, CancellationToken token)
+		private KtxFile EncodeToKtxInternal(Memory<ColorRgba32> input, int width, int height, CancellationToken token)
+		{
+			return EncodeToKtxInternal(input.AsMemory2D(width, height), token);
+		}
+
+		private KtxFile EncodeToKtxInternal(Memory2D<ColorRgba32> input, CancellationToken token)
 		{
 			KtxFile output;
 			IBcBlockEncoder compressedEncoder = null;
 			IRawEncoder uncompressedEncoder = null;
 
 			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			// Setup encoders
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+			if (isCompressedFormat)
 			{
-				// Setup encoders
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
+				{
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
+				}
+
+				output = new KtxFile(
+					KtxHeader.InitializeCompressed(input.Width, input.Height,
+						compressedEncoder.GetInternalFormat(),
+						compressedEncoder.GetBaseInternalFormat()));
+			}
+			else
+			{
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+				output = new KtxFile(
+					KtxHeader.InitializeUncompressed(input.Width, input.Height,
+						uncompressedEncoder.GetGlType(),
+						uncompressedEncoder.GetGlFormat(),
+						uncompressedEncoder.GetGlTypeSize(),
+						uncompressedEncoder.GetInternalFormat(),
+						uncompressedEncoder.GetBaseInternalFormat()));
+			}
+
+			var context = new OperationContext
+			{
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
+
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
+
+			// Encode mipmap levels
+			for (var mip = 0; mip < numMipMaps; mip++)
+			{
+				byte[] encoded;
 				if (isCompressedFormat)
 				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
+					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip], out var blocksWidth,
+						out var blocksHeight);
+					encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality,
+						context);
 
-					output = new KtxFile(
-						KtxHeader.InitializeCompressed(width, height,
-							compressedEncoder.GetInternalFormat(),
-							compressedEncoder.GetBaseInternalFormat()));
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
 				}
 				else
 				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-					output = new KtxFile(
-						KtxHeader.InitializeUncompressed(width, height,
-							uncompressedEncoder.GetGlType(),
-							uncompressedEncoder.GetGlFormat(),
-							uncompressedEncoder.GetGlTypeSize(),
-							uncompressedEncoder.GetInternalFormat(),
-							uncompressedEncoder.GetBaseInternalFormat()));
-				}
-
-				var context = new OperationContext
-				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode mipmap levels
-				for (var mip = 0; mip < numMipMaps; mip++)
-				{
-					byte[] encoded;
-					if (isCompressedFormat)
+					if (!mipChain[mip].TryGetMemory(out var mipMemory))
 					{
-						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth,
-							out var blocksHeight);
-						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality,
-							context);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
-					}
-					else
-					{
-						if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-							throw new Exception("Cannot get pixel span.");
-
-						encoded = uncompressedEncoder.Encode(mipPixels);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
+						throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
 					}
 
-					output.MipMaps.Add(new KtxMipmap((uint)encoded.Length,
-						(uint)mipChain[mip].Width,
-						(uint)mipChain[mip].Height, 1));
-					output.MipMaps[mip].Faces[0] = new KtxMipFace(encoded,
-						(uint)mipChain[mip].Width,
-						(uint)mipChain[mip].Height);
+					encoded = uncompressedEncoder.Encode(mipMemory);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
 				}
 
-				output.header.NumberOfFaces = 1;
-				output.header.NumberOfMipmapLevels = (uint)numMipMaps;
+				output.MipMaps.Add(new KtxMipmap((uint)encoded.Length,
+					(uint)mipChain[mip].Width,
+					(uint)mipChain[mip].Height, 1));
+				output.MipMaps[mip].Faces[0] = new KtxMipFace(encoded,
+					(uint)mipChain[mip].Width,
+					(uint)mipChain[mip].Height);
+			}
 
-				return output;
-			}
-			finally
-			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
-			}
+			output.header.NumberOfFaces = 1;
+			output.header.NumberOfMipmapLevels = (uint)numMipMaps;
+
+			return output;
 		}
 
-		private DdsFile EncodeToDdsInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, CancellationToken token)
+		private DdsFile EncodeToDdsInternal(Memory<ColorRgba32> input, int width, int height, CancellationToken token)
+		{
+			return EncodeToDdsInternal(input.AsMemory2D(width, height), token);
+		}
+
+		private DdsFile EncodeToDdsInternal(Memory2D<ColorRgba32> input, CancellationToken token)
 		{
 			DdsFile output;
 			IBcBlockEncoder compressedEncoder = null;
 			IRawEncoder uncompressedEncoder = null;
 
 			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			// Setup encoder
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+			if (isCompressedFormat)
 			{
-				// Setup encoder
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
-				if (isCompressedFormat)
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
 				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
-
-					var (ddsHeader, dxt10Header) = DdsHeader.InitializeCompressed(width, height,
-						compressedEncoder.GetDxgiFormat());
-					output = new DdsFile(ddsHeader, dxt10Header);
-
-					if (OutputOptions.DdsBc1WriteAlphaFlag &&
-						OutputOptions.Format == CompressionFormat.Bc1WithAlpha)
-					{
-						output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphapixels;
-					}
-				}
-				else
-				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-					var ddsHeader = DdsHeader.InitializeUncompressed(width, height,
-						uncompressedEncoder.GetDxgiFormat());
-					output = new DdsFile(ddsHeader);
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
 				}
 
-				var context = new OperationContext
+				var (ddsHeader, dxt10Header) = DdsHeader.InitializeCompressed(input.Width, input.Height,
+					compressedEncoder.GetDxgiFormat());
+				output = new DdsFile(ddsHeader, dxt10Header);
+
+				if (OutputOptions.DdsBc1WriteAlphaFlag &&
+					OutputOptions.Format == CompressionFormat.Bc1WithAlpha)
 				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode mipmap levels
-				for (var mip = 0; mip < numMipMaps; mip++)
-				{
-					byte[] encoded;
-					if (isCompressedFormat)
-					{
-						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth, out var blocksHeight);
-						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
-					}
-					else
-					{
-						if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-						{
-							throw new Exception("Cannot get pixel span.");
-						}
-
-						encoded = uncompressedEncoder.Encode(mipPixels);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
-					}
-
-					if (mip == 0)
-					{
-						output.Faces.Add(new DdsFace((uint)width, (uint)height,
-							(uint)encoded.Length, (int)numMipMaps));
-					}
-
-					output.Faces[0].MipMaps[mip] = new DdsMipMap(encoded,
-						(uint)mipChain[mip].Width,
-						(uint)mipChain[mip].Height);
+					output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphapixels;
 				}
-
-
-				output.header.dwMipMapCount = (uint)numMipMaps;
-				if (numMipMaps > 1)
-				{
-					output.header.dwCaps |= HeaderCaps.DdscapsComplex | HeaderCaps.DdscapsMipmap;
-				}
-
-				return output;
 			}
-			finally
+			else
 			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
-			}
-		}
-
-		private IList<byte[]> EncodeToRawBytesInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, CancellationToken token)
-		{
-			if (inputPixelsRgba.Length != width * height * 4)
-			{
-				throw new ArgumentException("The input pixels must be provided in 4 bytes per pixel rgba format.");
-			}
-			
-			var output = new List<byte[]>();
-			IBcBlockEncoder compressedEncoder = null;
-			IRawEncoder uncompressedEncoder = null;
-
-			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
-			{
-				// Setup encoder
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
-
-				if (isCompressedFormat)
-				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
-				}
-				else
-				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-				}
-
-				var context = new OperationContext
-				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode all mipmap levels
-				for (var mip = 0; mip < numMipMaps; mip++)
-				{
-					byte[] encoded;
-					if (isCompressedFormat)
-					{
-						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth, out var blocksHeight);
-						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
-					}
-					else
-					{
-						if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-						{
-							throw new Exception("Cannot get pixel span.");
-						}
-
-						encoded = uncompressedEncoder.Encode(mipPixels);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
-					}
-
-					output.Add(encoded);
-				}
-
-
-				return output;
-			}
-			finally
-			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
-			}
-		}
-
-		private byte[] EncodeToRawBytesInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
-		{
-			if (inputPixelsRgba.Length != width * height * 4)
-			{
-				throw new ArgumentException("The input pixels must be provided in 4 bytes per pixel rgba format.");
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+				var ddsHeader = DdsHeader.InitializeUncompressed(input.Width, input.Height,
+					uncompressedEncoder.GetDxgiFormat());
+				output = new DdsFile(ddsHeader);
 			}
 
-			if (mipLevel < 0)
-				throw new ArgumentException($"{nameof(mipLevel)} cannot be less than zero.");
-
-			IBcBlockEncoder compressedEncoder = null;
-			IRawEncoder uncompressedEncoder = null;
-
-			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
+			var context = new OperationContext
 			{
-				// Setup encoder
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
-				if (isCompressedFormat)
-				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
-				}
-				else
-				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-				}
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
 
-				// Dispose all mipmap levels
-				if (mipLevel > numMipMaps - 1)
-				{
-					throw new ArgumentException($"{nameof(mipLevel)} cannot be more than number of mipmaps.");
-				}
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
 
-				var context = new OperationContext
-				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? ImageToBlocks.CalculateNumOfBlocks(mipChain[mipLevel].Width, mipChain[mipLevel].Height) : mipChain[mipLevel].Width * mipChain[mipLevel].Height;
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode mipmap level
+			// Encode mipmap levels
+			for (var mip = 0; mip < numMipMaps; mip++)
+			{
 				byte[] encoded;
 				if (isCompressedFormat)
 				{
-					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mipLevel].Frames[0], out var blocksWidth, out var blocksHeight);
+					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip], out var blocksWidth, out var blocksHeight);
 					encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
 				}
 				else
 				{
-					if (!mipChain[mipLevel].TryGetSinglePixelSpan(out var mipPixels))
+					if (!mipChain[mip].TryGetMemory(out var mipMemory))
 					{
-						throw new Exception("Cannot get pixel span.");
+						throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
 					}
 
-					encoded = uncompressedEncoder.Encode(mipPixels);
+					encoded = uncompressedEncoder.Encode(mipMemory);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
 				}
 
-				mipWidth = mipChain[mipLevel].Width;
-				mipHeight = mipChain[mipLevel].Height;
+				if (mip == 0)
+				{
+					output.Faces.Add(new DdsFace((uint)input.Width, (uint)input.Height,
+						(uint)encoded.Length, numMipMaps));
+				}
 
-				return encoded;
+				output.Faces[0].MipMaps[mip] = new DdsMipMap(encoded,
+					(uint)mipChain[mip].Width,
+					(uint)mipChain[mip].Height);
 			}
-			finally
+
+
+			output.header.dwMipMapCount = (uint)numMipMaps;
+			if (numMipMaps > 1)
 			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
+				output.header.dwCaps |= HeaderCaps.DdscapsComplex | HeaderCaps.DdscapsMipmap;
 			}
+
+			return output;
 		}
 
-		private void EncodeCubeMapToStreamInternal(ReadOnlySpan<byte> right, ReadOnlySpan<byte> left, ReadOnlySpan<byte> top, ReadOnlySpan<byte> down,
-			ReadOnlySpan<byte> back, ReadOnlySpan<byte> front, int width, int height, Stream outputStream, CancellationToken token)
+		private IList<byte[]> EncodeToRawInternal(Memory<ColorRgba32> input, int width, int height, CancellationToken token)
+		{
+			return EncodeToRawInternal(input.AsMemory2D(width, height), token);
+		}
+
+		private IList<byte[]> EncodeToRawInternal(Memory2D<ColorRgba32> input, CancellationToken token)
+		{
+			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			var output = new List<byte[]>(numMipMaps);
+			IBcBlockEncoder compressedEncoder = null;
+			IRawEncoder uncompressedEncoder = null;
+
+			// Setup encoder
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+
+			if (isCompressedFormat)
+			{
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
+				{
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
+				}
+			}
+			else
+			{
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+			}
+
+			var context = new OperationContext
+			{
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
+
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
+
+			// Encode all mipmap levels
+			for (var mip = 0; mip < numMipMaps; mip++)
+			{
+				byte[] encoded;
+				if (isCompressedFormat)
+				{
+					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip], out var blocksWidth, out var blocksHeight);
+					encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
+				}
+				else
+				{
+					if (!mipChain[mip].TryGetMemory(out var mipMemory))
+					{
+						throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
+					}
+
+					encoded = uncompressedEncoder.Encode(mipMemory);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
+				}
+
+				output.Add(encoded);
+			}
+
+			return output;
+		}
+
+		private byte[] EncodeToRawInternal(Memory<ColorRgba32> input, int width, int height, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
+		{
+			return EncodeToRawInternal(input.AsMemory2D(width, height), mipLevel, out mipWidth, out mipHeight, token);
+		}
+
+		private byte[] EncodeToRawInternal(Memory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
+		{
+			mipLevel = Math.Max(0, mipLevel);
+
+			IBcBlockEncoder compressedEncoder = null;
+			IRawEncoder uncompressedEncoder = null;
+
+			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			// Setup encoder
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+			if (isCompressedFormat)
+			{
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
+				{
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
+				}
+			}
+			else
+			{
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+			}
+
+			// Dispose all mipmap levels
+			if (mipLevel > numMipMaps - 1)
+			{
+				throw new ArgumentException($"{nameof(mipLevel)} cannot be more than number of mipmaps.");
+			}
+
+			var context = new OperationContext
+			{
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
+
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? ImageToBlocks.CalculateNumOfBlocks(mipChain[mipLevel].Width, mipChain[mipLevel].Height) : mipChain[mipLevel].Width * mipChain[mipLevel].Height;
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
+
+			// Encode mipmap level
+			byte[] encoded;
+			if (isCompressedFormat)
+			{
+				var blocks = ImageToBlocks.ImageTo4X4(mipChain[mipLevel], out var blocksWidth, out var blocksHeight);
+				encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+			}
+			else
+			{
+				if (!mipChain[mipLevel].TryGetMemory(out var mipMemory))
+				{
+					throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
+				}
+
+				encoded = uncompressedEncoder.Encode(mipMemory);
+			}
+
+			mipWidth = mipChain[mipLevel].Width;
+			mipHeight = mipChain[mipLevel].Height;
+
+			return encoded;
+		}
+
+		private void EncodeCubeMapToStreamInternal(Memory<ColorRgba32> right, Memory<ColorRgba32> left, Memory<ColorRgba32> top, Memory<ColorRgba32> down,
+			Memory<ColorRgba32> back, Memory<ColorRgba32> front, int width, int height, Stream outputStream, CancellationToken token)
+		{
+			EncodeCubeMapToStreamInternal(
+				right.AsMemory2D(width, height), left.AsMemory2D(width, height),
+				top.AsMemory2D(width, height), down.AsMemory2D(width, height),
+				back.AsMemory2D(width, height), front.AsMemory2D(width, height),
+				outputStream, token);
+		}
+
+		private void EncodeCubeMapToStreamInternal(Memory2D<ColorRgba32> right, Memory2D<ColorRgba32> left, Memory2D<ColorRgba32> top, Memory2D<ColorRgba32> down,
+			Memory2D<ColorRgba32> back, Memory2D<ColorRgba32> front, Stream outputStream, CancellationToken token)
 		{
 			switch (OutputOptions.FileFormat)
 			{
 				case OutputFileFormat.Ktx:
-					var ktx = EncodeCubeMapToKtxInternal(right, left, top, down, back, front, width, height, token);
+					var ktx = EncodeCubeMapToKtxInternal(right, left, top, down, back, front, token);
 					ktx.Write(outputStream);
 					break;
 
 				case OutputFileFormat.Dds:
-					var dds = EncodeCubeMapToDdsInternal(right, left, top, down, back, front, width, height, token);
+					var dds = EncodeCubeMapToDdsInternal(right, left, top, down, back, front, token);
 					dds.Write(outputStream);
 					break;
 			}
 		}
 
-		private KtxFile EncodeCubeMapToKtxInternal(ReadOnlySpan<byte> right, ReadOnlySpan<byte> left, ReadOnlySpan<byte> top, ReadOnlySpan<byte> down,
-			ReadOnlySpan<byte> back, ReadOnlySpan<byte> front, int width, int height, CancellationToken token)
+		private KtxFile EncodeCubeMapToKtxInternal(Memory<ColorRgba32> right, Memory<ColorRgba32> left, Memory<ColorRgba32> top, Memory<ColorRgba32> down,
+			Memory<ColorRgba32> back, Memory<ColorRgba32> front, int width, int height, Stream outputStream, CancellationToken token)
+		{
+			return EncodeCubeMapToKtxInternal(
+				right.AsMemory2D(width, height), left.AsMemory2D(width, height),
+				top.AsMemory2D(width, height), down.AsMemory2D(width, height),
+				back.AsMemory2D(width, height), front.AsMemory2D(width, height),
+				outputStream, token);
+		}
+
+		private KtxFile EncodeCubeMapToKtxInternal(Memory2D<ColorRgba32> right, Memory2D<ColorRgba32> left, Memory2D<ColorRgba32> top, Memory2D<ColorRgba32> down,
+			Memory2D<ColorRgba32> back, Memory2D<ColorRgba32> front, CancellationToken token)
 		{
 			KtxFile output;
 			IBcBlockEncoder compressedEncoder = null;
 			IRawEncoder uncompressedEncoder = null;
 
-			if (right.Length != width * height * 4)
-			{
-				throw new ArgumentException("The input pixels must be provided in 4 bytes per pixel rgba format.");
-			}
+			var faces = new[] { right, left, top, down, back, front };
 
-			if (right.Length != left.Length || right.Length != top.Length || right.Length != down.Length
-				|| right.Length != back.Length || right.Length != front.Length)
-			{
-				throw new ArgumentException("All input images of a cubemap should be the same size.");
-			}
-
-			var faces = new[] { right.ToArray(), left.ToArray(), top.ToArray(), down.ToArray(), back.ToArray(), front.ToArray() };
+			var width = right.Width;
+			var height = right.Height;
 
 			// Setup encoder
 			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
@@ -947,7 +795,7 @@ namespace BCnEncoder.Encoder
 				}
 
 				output = new KtxFile(
-					KtxHeader.InitializeCompressed(width, height,
+					KtxHeader.InitializeCompressed(width,height,
 						compressedEncoder.GetInternalFormat(),
 						compressedEncoder.GetBaseInternalFormat()));
 			}
@@ -955,7 +803,7 @@ namespace BCnEncoder.Encoder
 			{
 				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
 				output = new KtxFile(
-					KtxHeader.InitializeUncompressed(width, height,
+					KtxHeader.InitializeUncompressed(width,height,
 						uncompressedEncoder.GetGlType(),
 						uncompressedEncoder.GetGlFormat(),
 						uncompressedEncoder.GetGlTypeSize(),
@@ -965,7 +813,7 @@ namespace BCnEncoder.Encoder
 			}
 
 			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipLength = MipMapper.CalculateMipChainLength(width, height, numMipMaps);
+			var mipLength = MipMapper.CalculateMipChainLength(width,height, numMipMaps);
 			for (uint i = 0; i < mipLength; i++)
 			{
 				output.MipMaps.Add(new KtxMipmap(0, 0, 0, (uint)faces.Length));
@@ -984,7 +832,7 @@ namespace BCnEncoder.Encoder
 			{
 				for (var mip = 0; mip < numMipMaps; mip++)
 				{
-					MipMapper.CalculateMipLevelSize(width, height, mip, out var mipWidth, out var mipHeight);
+					MipMapper.CalculateMipLevelSize(width,height, mip, out var mipWidth, out var mipHeight);
 					totalBlocks += isCompressedFormat ? ImageToBlocks.CalculateNumOfBlocks(mipWidth, mipHeight) : mipWidth * mipHeight;
 				}
 			}
@@ -995,50 +843,42 @@ namespace BCnEncoder.Encoder
 			for (var face = 0; face < faces.Length; face++)
 			{
 				var mipChain = MipMapper.GenerateMipChain(faces[face], width, height, ref numMipMaps);
-				try
+
+				// Encode all mipmap levels per face
+				for (var mipLevel = 0; mipLevel < numMipMaps; mipLevel++)
 				{
-					// Encode all mipmap levels per face
-					for (var mip = 0; mip < numMipMaps; mip++)
+					byte[] encoded;
+					if (isCompressedFormat)
 					{
-						byte[] encoded;
-						if (isCompressedFormat)
-						{
-							var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth, out var blocksHeight);
-							encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mipLevel], out var blocksWidth, out var blocksHeight);
+						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
 
-							processedBlocks += blocks.Length;
-							context.Progress.SetProcessedBlocks(processedBlocks);
-						}
-						else
-						{
-							if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-							{
-								throw new Exception("Cannot get pixel span.");
-							}
-
-							encoded = uncompressedEncoder.Encode(mipPixels);
-
-							processedBlocks += mipPixels.Length;
-							context.Progress.SetProcessedBlocks(processedBlocks);
-						}
-
-						if (face == 0)
-						{
-							output.MipMaps[mip] = new KtxMipmap((uint)encoded.Length,
-								(uint)mipChain[mip].Width,
-								(uint)mipChain[mip].Height, (uint)faces.Length);
-						}
-
-						output.MipMaps[mip].Faces[face] = new KtxMipFace(encoded,
-							(uint)mipChain[mip].Width,
-							(uint)mipChain[mip].Height);
+						processedBlocks += blocks.Length;
+						context.Progress.SetProcessedBlocks(processedBlocks);
 					}
-				}
-				finally
-				{
-					// Dispose all mipmap levels, even if operation was cancelled
-					foreach (var image in mipChain)
-						image.Dispose();
+					else
+					{
+						if (!mipChain[mipLevel].TryGetMemory(out var mipMemory))
+						{
+							throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
+						}
+
+						encoded = uncompressedEncoder.Encode(mipMemory);
+
+						processedBlocks += mipMemory.Length;
+						context.Progress.SetProcessedBlocks(processedBlocks);
+					}
+
+					if (face == 0)
+					{
+						output.MipMaps[mipLevel] = new KtxMipmap((uint)encoded.Length,
+							(uint)mipChain[mipLevel].Width,
+							(uint)mipChain[mipLevel].Height, (uint)faces.Length);
+					}
+
+					output.MipMaps[mipLevel].Faces[face] = new KtxMipFace(encoded,
+						(uint)mipChain[mipLevel].Width,
+						(uint)mipChain[mipLevel].Height);
 				}
 			}
 
@@ -1061,7 +901,7 @@ namespace BCnEncoder.Encoder
 			}
 
 			if (right.Length != left.Length || right.Length != top.Length || right.Length != down.Length
-			    || right.Length != back.Length || right.Length != front.Length)
+				|| right.Length != back.Length || right.Length != front.Length)
 			{
 				throw new ArgumentException("All input images of a cubemap should be the same size.");
 			}

--- a/BCnEnc.Net/Encoder/ColorChooser.cs
+++ b/BCnEnc.Net/Encoder/ColorChooser.cs
@@ -1,27 +1,26 @@
-﻿using System;
+using System;
 using BCnEncoder.Shared;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder
 {
 	internal static class ColorChooser
 	{
 
-		public static int ChooseClosestColor4(ReadOnlySpan<ColorRgb24> colors, Rgba32 color, float rWeight, float gWeight, float bWeight, out float error)
+		public static int ChooseClosestColor4(ReadOnlySpan<ColorRgb24> colors, ColorRgba32 color, float rWeight, float gWeight, float bWeight, out float error)
 		{
 			ReadOnlySpan<float> d = stackalloc float[4] {
-				MathF.Abs(colors[0].r - color.R) * rWeight
-				+ MathF.Abs(colors[0].g - color.G) * gWeight
-				+ MathF.Abs(colors[0].b - color.B) * bWeight,
-				MathF.Abs(colors[1].r - color.R) * rWeight
-				+ MathF.Abs(colors[1].g - color.G) * gWeight
-				+ MathF.Abs(colors[1].b - color.B) * bWeight,
-				MathF.Abs(colors[2].r - color.R) * rWeight
-				+ MathF.Abs(colors[2].g - color.G) * gWeight
-				+ MathF.Abs(colors[2].b - color.B) * bWeight,
-				MathF.Abs(colors[3].r - color.R) * rWeight
-				+ MathF.Abs(colors[3].g - color.G) * gWeight
-				+ MathF.Abs(colors[3].b - color.B) * bWeight,
+				MathF.Abs(colors[0].r - color.r) * rWeight
+				+ MathF.Abs(colors[0].g - color.g) * gWeight
+				+ MathF.Abs(colors[0].b - color.b) * bWeight,
+				MathF.Abs(colors[1].r - color.r) * rWeight
+				+ MathF.Abs(colors[1].g - color.g) * gWeight
+				+ MathF.Abs(colors[1].b - color.b) * bWeight,
+				MathF.Abs(colors[2].r - color.r) * rWeight
+				+ MathF.Abs(colors[2].g - color.g) * gWeight
+				+ MathF.Abs(colors[2].b - color.b) * bWeight,
+				MathF.Abs(colors[3].r - color.r) * rWeight
+				+ MathF.Abs(colors[3].g - color.g) * gWeight
+				+ MathF.Abs(colors[3].b - color.b) * bWeight,
 			};
 
 			var b0 = d[0] > d[3] ? 1 : 0;
@@ -40,30 +39,30 @@ namespace BCnEncoder.Encoder
 		}
 
 
-		public static int ChooseClosestColor4AlphaCutoff(ReadOnlySpan<ColorRgb24> colors, Rgba32 color, float rWeight, float gWeight, float bWeight, int alphaCutoff, bool hasAlpha, out float error)
+		public static int ChooseClosestColor4AlphaCutoff(ReadOnlySpan<ColorRgb24> colors, ColorRgba32 color, float rWeight, float gWeight, float bWeight, int alphaCutoff, bool hasAlpha, out float error)
 		{
 
-			if (hasAlpha && color.A < alphaCutoff)
+			if (hasAlpha && color.a < alphaCutoff)
 			{
 				error = 0;
 				return 3;
 			}
 
 			ReadOnlySpan<float> d = stackalloc float[4] {
-				MathF.Abs(colors[0].r - color.R) * rWeight
-				+ MathF.Abs(colors[0].g - color.G) * gWeight
-				+ MathF.Abs(colors[0].b - color.B) * bWeight,
-				MathF.Abs(colors[1].r - color.R) * rWeight
-				+ MathF.Abs(colors[1].g - color.G) * gWeight
-				+ MathF.Abs(colors[1].b - color.B) * bWeight,
-				MathF.Abs(colors[2].r - color.R) * rWeight
-				+ MathF.Abs(colors[2].g - color.G) * gWeight
-				+ MathF.Abs(colors[2].b - color.B) * bWeight,
+				MathF.Abs(colors[0].r - color.r) * rWeight
+				+ MathF.Abs(colors[0].g - color.g) * gWeight
+				+ MathF.Abs(colors[0].b - color.b) * bWeight,
+				MathF.Abs(colors[1].r - color.r) * rWeight
+				+ MathF.Abs(colors[1].g - color.g) * gWeight
+				+ MathF.Abs(colors[1].b - color.b) * bWeight,
+				MathF.Abs(colors[2].r - color.r) * rWeight
+				+ MathF.Abs(colors[2].g - color.g) * gWeight
+				+ MathF.Abs(colors[2].b - color.b) * bWeight,
 
 				hasAlpha ? 999 :
-				MathF.Abs(colors[3].r - color.R) * rWeight
-				+ MathF.Abs(colors[3].g - color.G) * gWeight
-				+ MathF.Abs(colors[3].b - color.B) * bWeight,
+				MathF.Abs(colors[3].r - color.r) * rWeight
+				+ MathF.Abs(colors[3].g - color.g) * gWeight
+				+ MathF.Abs(colors[3].b - color.b) * bWeight,
 			};
 
 			var b0 = d[0] > d[2] ? 1 : 0;
@@ -80,20 +79,20 @@ namespace BCnEncoder.Encoder
 			return idx;
 		}
 
-		public static int ChooseClosestColor(Span<ColorRgb24> colors, Rgba32 color)
+		public static int ChooseClosestColor(Span<ColorRgb24> colors, ColorRgba32 color)
 		{
 			var closest = 0;
 			var closestError =
-				Math.Abs(colors[0].r - color.R)
-				+ Math.Abs(colors[0].g - color.G)
-				+ Math.Abs(colors[0].b - color.B);
+				Math.Abs(colors[0].r - color.r)
+				+ Math.Abs(colors[0].g - color.g)
+				+ Math.Abs(colors[0].b - color.b);
 
 			for (var i = 1; i < colors.Length; i++)
 			{
 				var error =
-					Math.Abs(colors[i].r - color.R)
-					+ Math.Abs(colors[i].g - color.G)
-					+ Math.Abs(colors[i].b - color.B);
+					Math.Abs(colors[i].r - color.r)
+					+ Math.Abs(colors[i].g - color.g)
+					+ Math.Abs(colors[i].b - color.b);
 				if (error < closestError)
 				{
 					closest = i;
@@ -103,22 +102,22 @@ namespace BCnEncoder.Encoder
 			return closest;
 		}
 
-		public static int ChooseClosestColor(Span<ColorRgba32> colors, Rgba32 color)
+		public static int ChooseClosestColor(Span<ColorRgba32> colors, ColorRgba32 color)
 		{
 			var closest = 0;
 			var closestError =
-				Math.Abs(colors[0].r - color.R)
-				+ Math.Abs(colors[0].g - color.G)
-				+ Math.Abs(colors[0].b - color.B)
-				+ Math.Abs(colors[0].a - color.A);
+				Math.Abs(colors[0].r - color.r)
+				+ Math.Abs(colors[0].g - color.g)
+				+ Math.Abs(colors[0].b - color.b)
+				+ Math.Abs(colors[0].a - color.a);
 
 			for (var i = 1; i < colors.Length; i++)
 			{
 				var error =
-					Math.Abs(colors[i].r - color.R)
-					+ Math.Abs(colors[i].g - color.G)
-					+ Math.Abs(colors[i].b - color.B)
-					+ Math.Abs(colors[i].a - color.A);
+					Math.Abs(colors[i].r - color.r)
+					+ Math.Abs(colors[i].g - color.g)
+					+ Math.Abs(colors[i].b - color.b)
+					+ Math.Abs(colors[i].a - color.a);
 				if (error < closestError)
 				{
 					closest = i;
@@ -128,26 +127,26 @@ namespace BCnEncoder.Encoder
 			return closest;
 		}
 
-		public static int ChooseClosestColorAlphaCutOff(Span<ColorRgba32> colors, Rgba32 color, byte alphaCutOff = 255 / 2)
+		public static int ChooseClosestColorAlphaCutOff(Span<ColorRgba32> colors, ColorRgba32 color, byte alphaCutOff = 255 / 2)
 		{
-			if (color.A <= alphaCutOff)
+			if (color.a <= alphaCutOff)
 			{
 				return 3;
 			}
 
 			var closest = 0;
 			var closestError =
-				Math.Abs(colors[0].r - color.R)
-				+ Math.Abs(colors[0].g - color.G)
-				+ Math.Abs(colors[0].b - color.B);
+				Math.Abs(colors[0].r - color.r)
+				+ Math.Abs(colors[0].g - color.g)
+				+ Math.Abs(colors[0].b - color.b);
 
 			for (var i = 1; i < colors.Length; i++)
 			{
 				if (i == 3) continue; // Skip transparent
 				var error =
-					Math.Abs(colors[i].r - color.R)
-					+ Math.Abs(colors[i].g - color.G)
-					+ Math.Abs(colors[i].b - color.B);
+					Math.Abs(colors[i].r - color.r)
+					+ Math.Abs(colors[i].g - color.g)
+					+ Math.Abs(colors[i].b - color.b);
 				if (error < closestError)
 				{
 					closest = i;
@@ -182,7 +181,7 @@ namespace BCnEncoder.Encoder
 			return closest;
 		}
 
-		public static int ChooseClosestColor(Span<ColorYCbCr> colors, Rgba32 color, float luminanceMultiplier = 4)
+		public static int ChooseClosestColor(Span<ColorYCbCr> colors, ColorRgba32 color, float luminanceMultiplier = 4)
 			=> ChooseClosestColor(colors, new ColorYCbCr(color), luminanceMultiplier);
 	}
 }

--- a/BCnEnc.Net/Encoder/IBcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/IBcBlockEncoder.cs
@@ -1,4 +1,5 @@
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -1,13 +1,12 @@
 using System;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder
 {
 	internal interface IRawEncoder
 	{
-		byte[] Encode(ReadOnlySpan<Rgba32> pixels);
+		byte[] Encode(Memory<ColorRgba32> pixels);
 		GlInternalFormat GetInternalFormat();
 		GlFormat GetBaseInternalFormat();
 		GlFormat GetGlFormat();
@@ -25,18 +24,20 @@ namespace BCnEncoder.Encoder
 			this.useLuminance = useLuminance;
 		}
 
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length];
 			for (var i = 0; i < pixels.Length; i++)
 			{
 				if (useLuminance)
 				{
-					output[i] = (byte)(new ColorYCbCr(pixels[i]).y * 255);
+					output[i] = (byte)(new ColorYCbCr(span[i]).y * 255);
 				}
 				else
 				{
-					output[i] = pixels[i].R;
+					output[i] = span[i].R;
 				}
 
 			}
@@ -76,13 +77,15 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 2];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 2] = pixels[i].R;
-				output[i * 2 + 1] = pixels[i].G;
+				output[i * 2] = span[i].R;
+				output[i * 2 + 1] = span[i].G;
 			}
 			return output;
 		}
@@ -120,14 +123,16 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgbEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 3];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 3] = pixels[i].R;
-				output[i * 3 + 1] = pixels[i].G;
-				output[i * 3 + 2] = pixels[i].B;
+				output[i * 3] = span[i].R;
+				output[i * 3 + 1] = span[i].G;
+				output[i * 3 + 2] = span[i].B;
 			}
 			return output;
 		}
@@ -165,15 +170,17 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgbaEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = pixels[i].R;
-				output[i * 4 + 1] = pixels[i].G;
-				output[i * 4 + 2] = pixels[i].B;
-				output[i * 4 + 3] = pixels[i].A;
+				output[i * 4] = span[i].R;
+				output[i * 4 + 1] = span[i].G;
+				output[i * 4 + 2] = span[i].B;
+				output[i * 4 + 3] = span[i].A;
 			}
 			return output;
 		}
@@ -211,15 +218,17 @@ namespace BCnEncoder.Encoder
 
 	internal class RawBgraEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = pixels[i].B;
-				output[i * 4 + 1] = pixels[i].G;
-				output[i * 4 + 2] = pixels[i].R;
-				output[i * 4 + 3] = pixels[i].A;
+				output[i * 4] = span[i].B;
+				output[i * 4 + 1] = span[i].G;
+				output[i * 4 + 2] = span[i].R;
+				output[i * 4 + 3] = span[i].A;
 			}
 			return output;
 		}

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -37,7 +37,7 @@ namespace BCnEncoder.Encoder
 				}
 				else
 				{
-					output[i] = span[i].R;
+					output[i] = span[i].r;
 				}
 
 			}
@@ -84,8 +84,8 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 2];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 2] = span[i].R;
-				output[i * 2 + 1] = span[i].G;
+				output[i * 2] = span[i].r;
+				output[i * 2 + 1] = span[i].g;
 			}
 			return output;
 		}
@@ -130,9 +130,9 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 3];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 3] = span[i].R;
-				output[i * 3 + 1] = span[i].G;
-				output[i * 3 + 2] = span[i].B;
+				output[i * 3] = span[i].r;
+				output[i * 3 + 1] = span[i].g;
+				output[i * 3 + 2] = span[i].b;
 			}
 			return output;
 		}
@@ -177,10 +177,10 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = span[i].R;
-				output[i * 4 + 1] = span[i].G;
-				output[i * 4 + 2] = span[i].B;
-				output[i * 4 + 3] = span[i].A;
+				output[i * 4] = span[i].r;
+				output[i * 4 + 1] = span[i].g;
+				output[i * 4 + 2] = span[i].b;
+				output[i * 4 + 3] = span[i].a;
 			}
 			return output;
 		}
@@ -225,10 +225,10 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = span[i].B;
-				output[i * 4 + 1] = span[i].G;
-				output[i * 4 + 2] = span[i].R;
-				output[i * 4 + 3] = span[i].A;
+				output[i * 4] = span[i].b;
+				output[i * 4 + 1] = span[i].g;
+				output[i * 4 + 2] = span[i].r;
+				output[i * 4 + 3] = span[i].a;
 			}
 			return output;
 		}

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder

--- a/BCnEnc.Net/Shared/Bc7Block.cs
+++ b/BCnEnc.Net/Shared/Bc7Block.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -826,7 +826,7 @@ namespace BCnEncoder.Shared
 					outputColor = SwapChannels(outputColor, rotation);
 				}
 
-				pixels[i] = outputColor.ToRgba32();
+				pixels[i] = outputColor;
 			}
 
 			return output;

--- a/BCnEnc.Net/Shared/Colors.cs
+++ b/BCnEnc.Net/Shared/Colors.cs
@@ -163,7 +163,7 @@ namespace BCnEncoder.Shared
 			);
 		}
 
-		public static implicit operator ColorRgba32(ColorRgb24 d) => new ColorRgba32(d.r, d.g, d.b, 255);
+		//public static implicit operator ColorRgba32(ColorRgb24 d) => new ColorRgba32(d.r, d.g, d.b, 255);
 
 		public override string ToString()
 		{
@@ -184,7 +184,7 @@ namespace BCnEncoder.Shared
 			this.cr = cr;
 		}
 
-		public ColorYCbCr(ColorRgb24 rgb)
+		internal ColorYCbCr(ColorRgb24 rgb)
 		{
 			var fr = (float)rgb.r / 255;
 			var fg = (float)rgb.g / 255;
@@ -195,7 +195,7 @@ namespace BCnEncoder.Shared
 			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
 		}
 
-		public ColorYCbCr(ColorRgb565 rgb)
+		internal ColorYCbCr(ColorRgb565 rgb)
 		{
 			var fr = (float)rgb.R / 255;
 			var fg = (float)rgb.G / 255;
@@ -228,7 +228,7 @@ namespace BCnEncoder.Shared
 			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
 		}
 
-		public ColorRgb565 ToColorRgb565()
+		internal ColorRgb565 ToColorRgb565()
 		{
 			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
 			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
@@ -445,7 +445,7 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	public struct ColorRgb565 : IEquatable<ColorRgb565>
+	internal struct ColorRgb565 : IEquatable<ColorRgb565>
 	{
 		public bool Equals(ColorRgb565 other)
 		{
@@ -601,7 +601,7 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	public struct ColorRgb24 : IEquatable<ColorRgb24>
+	internal struct ColorRgb24 : IEquatable<ColorRgb24>
 	{
 		public byte r, g, b;
 

--- a/BCnEnc.Net/Shared/Colors.cs
+++ b/BCnEnc.Net/Shared/Colors.cs
@@ -4,6 +4,305 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
+	public struct ColorRgba32 : IEquatable<ColorRgba32>
+	{
+		public byte r, g, b, a;
+		public ColorRgba32(byte r, byte g, byte b, byte a)
+		{
+			this.r = r;
+			this.g = g;
+			this.b = b;
+			this.a = a;
+		}
+
+		public ColorRgba32(Rgba32 color)
+		{
+			this.r = color.R;
+			this.g = color.G;
+			this.b = color.B;
+			this.a = color.A;
+		}
+
+		public bool Equals(ColorRgba32 other)
+		{
+			return r == other.r && g == other.g && b == other.b && a == other.a;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is ColorRgba32 other && Equals(other);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				var hashCode = r.GetHashCode();
+				hashCode = (hashCode * 397) ^ g.GetHashCode();
+				hashCode = (hashCode * 397) ^ b.GetHashCode();
+				hashCode = (hashCode * 397) ^ a.GetHashCode();
+				return hashCode;
+			}
+		}
+
+		public static bool operator ==(ColorRgba32 left, ColorRgba32 right)
+		{
+			return left.Equals(right);
+		}
+
+		public static bool operator !=(ColorRgba32 left, ColorRgba32 right)
+		{
+			return !left.Equals(right);
+		}
+
+		public static ColorRgba32 operator +(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r + right.r),
+				ByteHelper.ClampToByte(left.g + right.g),
+				ByteHelper.ClampToByte(left.b + right.b),
+				ByteHelper.ClampToByte(left.a + right.a));
+		}
+
+		public static ColorRgba32 operator -(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r - right.r),
+				ByteHelper.ClampToByte(left.g - right.g),
+				ByteHelper.ClampToByte(left.b - right.b),
+				ByteHelper.ClampToByte(left.a - right.a));
+		}
+
+		public static ColorRgba32 operator /(ColorRgba32 left, double right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte((int)(left.r / right)),
+				ByteHelper.ClampToByte((int)(left.g / right)),
+				ByteHelper.ClampToByte((int)(left.b / right)),
+				ByteHelper.ClampToByte((int)(left.a / right))
+			);
+		}
+
+		public static ColorRgba32 operator *(ColorRgba32 left, double right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte((int)(left.r * right)),
+				ByteHelper.ClampToByte((int)(left.g * right)),
+				ByteHelper.ClampToByte((int)(left.b * right)),
+				ByteHelper.ClampToByte((int)(left.a * right))
+			);
+		}
+
+		/// <summary>
+		/// Component-wise left shift
+		/// </summary>
+		public static ColorRgba32 operator <<(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r << right),
+				ByteHelper.ClampToByte(left.g << right),
+				ByteHelper.ClampToByte(left.b << right),
+				ByteHelper.ClampToByte(left.a << right)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise right shift
+		/// </summary>
+		public static ColorRgba32 operator >>(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r >> right),
+				ByteHelper.ClampToByte(left.g >> right),
+				ByteHelper.ClampToByte(left.b >> right),
+				ByteHelper.ClampToByte(left.a >> right)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise OR operation
+		/// </summary>
+		public static ColorRgba32 operator |(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r | right.r),
+				ByteHelper.ClampToByte(left.g | right.g),
+				ByteHelper.ClampToByte(left.b | right.b),
+				ByteHelper.ClampToByte(left.a | right.a)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise OR operation
+		/// </summary>
+		public static ColorRgba32 operator |(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r | right),
+				ByteHelper.ClampToByte(left.g | right),
+				ByteHelper.ClampToByte(left.b | right),
+				ByteHelper.ClampToByte(left.a | right)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise AND operation
+		/// </summary>
+		public static ColorRgba32 operator &(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r & right.r),
+				ByteHelper.ClampToByte(left.g & right.g),
+				ByteHelper.ClampToByte(left.b & right.b),
+				ByteHelper.ClampToByte(left.a & right.a)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise AND operation
+		/// </summary>
+		public static ColorRgba32 operator &(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r & right),
+				ByteHelper.ClampToByte(left.g & right),
+				ByteHelper.ClampToByte(left.b & right),
+				ByteHelper.ClampToByte(left.a & right)
+			);
+		}
+
+		public override string ToString()
+		{
+			return $"r : {r} g : {g} b : {b} a : {a}";
+		}
+
+		public Rgba32 ToRgba32()
+		{
+			return new Rgba32(r, g, b, a);
+		}
+	}
+
+	public struct ColorYCbCr
+	{
+		public float y;
+		public float cb;
+		public float cr;
+
+		public ColorYCbCr(float y, float cb, float cr)
+		{
+			this.y = y;
+			this.cb = cb;
+			this.cr = cr;
+		}
+
+		public ColorYCbCr(ColorRgb24 rgb)
+		{
+			var fr = (float)rgb.r / 255;
+			var fg = (float)rgb.g / 255;
+			var fb = (float)rgb.b / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(ColorRgb565 rgb)
+		{
+			var fr = (float)rgb.R / 255;
+			var fg = (float)rgb.G / 255;
+			var fb = (float)rgb.B / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(ColorRgba32 rgba)
+		{
+			var fr = (float)rgba.r / 255;
+			var fg = (float)rgba.g / 255;
+			var fb = (float)rgba.b / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(Rgba32 rgb)
+		{
+			var fr = (float)rgb.R / 255;
+			var fg = (float)rgb.G / 255;
+			var fb = (float)rgb.B / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(Vector3 vec)
+		{
+			var fr = (float)vec.X;
+			var fg = (float)vec.Y;
+			var fb = (float)vec.Z;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorRgb565 ToColorRgb565()
+		{
+			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
+			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
+			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
+
+			return new ColorRgb565((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+		}
+
+		public override string ToString()
+		{
+			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
+			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
+			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
+
+			return $"r : {r * 255} g : {g * 255} b : {b * 255}";
+		}
+
+		public float CalcDistWeighted(ColorYCbCr other, float yWeight = 4)
+		{
+			var dy = (y - other.y) * (y - other.y) * yWeight;
+			var dcb = (cb - other.cb) * (cb - other.cb);
+			var dcr = (cr - other.cr) * (cr - other.cr);
+
+			return MathF.Sqrt(dy + dcb + dcr);
+		}
+
+		public static ColorYCbCr operator +(ColorYCbCr left, ColorYCbCr right)
+		{
+			return new ColorYCbCr(
+				left.y + right.y,
+				left.cb + right.cb,
+				left.cr + right.cr);
+		}
+
+		public static ColorYCbCr operator /(ColorYCbCr left, float right)
+		{
+			return new ColorYCbCr(
+				left.y / right,
+				left.cb / right,
+				left.cr / right);
+		}
+
+		public Rgba32 ToRgba32()
+		{
+			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
+			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
+			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
+
+			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), 255);
+		}
+	}
+
 	internal struct ColorRgb555 : IEquatable<ColorRgb555>
 	{
 		public bool Equals(ColorRgb555 other)
@@ -314,182 +613,6 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	internal struct ColorRgba32 : IEquatable<ColorRgba32>
-	{
-		public byte r, g, b, a;
-		public ColorRgba32(byte r, byte g, byte b, byte a)
-		{
-			this.r = r;
-			this.g = g;
-			this.b = b;
-			this.a = a;
-		}
-
-		public ColorRgba32(Rgba32 color)
-		{
-			this.r = color.R;
-			this.g = color.G;
-			this.b = color.B;
-			this.a = color.A;
-		}
-
-		public bool Equals(ColorRgba32 other)
-		{
-			return r == other.r && g == other.g && b == other.b && a == other.a;
-		}
-
-		public override bool Equals(object obj)
-		{
-			return obj is ColorRgba32 other && Equals(other);
-		}
-
-		public override int GetHashCode()
-		{
-			unchecked
-			{
-				var hashCode = r.GetHashCode();
-				hashCode = (hashCode * 397) ^ g.GetHashCode();
-				hashCode = (hashCode * 397) ^ b.GetHashCode();
-				hashCode = (hashCode * 397) ^ a.GetHashCode();
-				return hashCode;
-			}
-		}
-
-		public static bool operator ==(ColorRgba32 left, ColorRgba32 right)
-		{
-			return left.Equals(right);
-		}
-
-		public static bool operator !=(ColorRgba32 left, ColorRgba32 right)
-		{
-			return !left.Equals(right);
-		}
-
-		public static ColorRgba32 operator +(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r + right.r),
-				ByteHelper.ClampToByte(left.g + right.g),
-				ByteHelper.ClampToByte(left.b + right.b),
-				ByteHelper.ClampToByte(left.a + right.a));
-		}
-
-		public static ColorRgba32 operator -(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r - right.r),
-				ByteHelper.ClampToByte(left.g - right.g),
-				ByteHelper.ClampToByte(left.b - right.b),
-				ByteHelper.ClampToByte(left.a - right.a));
-		}
-
-		public static ColorRgba32 operator /(ColorRgba32 left, double right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte((int)(left.r / right)),
-				ByteHelper.ClampToByte((int)(left.g / right)),
-				ByteHelper.ClampToByte((int)(left.b / right)),
-				ByteHelper.ClampToByte((int)(left.a / right))
-			);
-		}
-
-		public static ColorRgba32 operator *(ColorRgba32 left, double right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte((int)(left.r * right)),
-				ByteHelper.ClampToByte((int)(left.g * right)),
-				ByteHelper.ClampToByte((int)(left.b * right)),
-				ByteHelper.ClampToByte((int)(left.a * right))
-			);
-		}
-
-		/// <summary>
-		/// Component-wise left shift
-		/// </summary>
-		public static ColorRgba32 operator <<(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r << right),
-				ByteHelper.ClampToByte(left.g << right),
-				ByteHelper.ClampToByte(left.b << right),
-				ByteHelper.ClampToByte(left.a << right)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise right shift
-		/// </summary>
-		public static ColorRgba32 operator >>(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r >> right),
-				ByteHelper.ClampToByte(left.g >> right),
-				ByteHelper.ClampToByte(left.b >> right),
-				ByteHelper.ClampToByte(left.a >> right)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise OR operation
-		/// </summary>
-		public static ColorRgba32 operator |(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r | right.r),
-				ByteHelper.ClampToByte(left.g | right.g),
-				ByteHelper.ClampToByte(left.b | right.b),
-				ByteHelper.ClampToByte(left.a | right.a)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise OR operation
-		/// </summary>
-		public static ColorRgba32 operator |(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r | right),
-				ByteHelper.ClampToByte(left.g | right),
-				ByteHelper.ClampToByte(left.b | right),
-				ByteHelper.ClampToByte(left.a | right)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise AND operation
-		/// </summary>
-		public static ColorRgba32 operator &(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r & right.r),
-				ByteHelper.ClampToByte(left.g & right.g),
-				ByteHelper.ClampToByte(left.b & right.b),
-				ByteHelper.ClampToByte(left.a & right.a)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise AND operation
-		/// </summary>
-		public static ColorRgba32 operator &(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r & right),
-				ByteHelper.ClampToByte(left.g & right),
-				ByteHelper.ClampToByte(left.b & right),
-				ByteHelper.ClampToByte(left.a & right)
-			);
-		}
-
-		public override string ToString() {
-			return $"r : {r} g : {g} b : {b} a : {a}";
-		}
-
-		public Rgba32 ToRgba32() {
-			return new Rgba32(r, g, b, a);
-		}
-	}
-
 	internal struct ColorRgb24 : IEquatable<ColorRgb24>
 	{
 		public byte r, g, b;
@@ -585,122 +708,6 @@ namespace BCnEncoder.Shared
 
 		public override string ToString() {
 			return $"r : {r} g : {g} b : {b}";
-		}
-	}
-
-	internal struct ColorYCbCr
-	{
-		public float y;
-		public float cb;
-		public float cr;
-
-		public ColorYCbCr(float y, float cb, float cr)
-		{
-			this.y = y;
-			this.cb = cb;
-			this.cr = cr;
-		}
-
-		public ColorYCbCr(ColorRgb24 rgb)
-		{
-			var fr = (float)rgb.r / 255;
-			var fg = (float)rgb.g / 255;
-			var fb = (float)rgb.b / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(ColorRgb565 rgb)
-		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(ColorRgba32 rgba)
-		{
-			var fr = (float)rgba.r / 255;
-			var fg = (float)rgba.g / 255;
-			var fb = (float)rgba.b / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(Rgba32 rgb)
-		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(Vector3 vec) {
-			var fr = (float) vec.X;
-			var fg = (float) vec.Y;
-			var fb = (float) vec.Z;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorRgb565 ToColorRgb565() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new ColorRgb565((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
-		}
-
-		public override string ToString() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return $"r : {r * 255} g : {g * 255} b : {b * 255}";
-		}
-
-		public float CalcDistWeighted(ColorYCbCr other, float yWeight = 4) {
-			var dy = (y - other.y) * (y - other.y) * yWeight;
-			var dcb = (cb - other.cb) * (cb - other.cb);
-			var dcr = (cr - other.cr) * (cr - other.cr);
-
-			return MathF.Sqrt(dy + dcb + dcr);
-		}
-
-		public static ColorYCbCr operator+(ColorYCbCr left, ColorYCbCr right)
-		{
-			return new ColorYCbCr(
-				left.y + right.y,
-				left.cb + right.cb,
-				left.cr + right.cr);
-		}
-
-		public static ColorYCbCr operator/(ColorYCbCr left, float right)
-		{
-			return new ColorYCbCr(
-				left.y / right,
-				left.cb / right,
-				left.cr / right);
-		}
-
-		public Rgba32 ToRgba32() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), 255);
 		}
 	}
 

--- a/BCnEnc.Net/Shared/Colors.cs
+++ b/BCnEnc.Net/Shared/Colors.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Numerics;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
 	public struct ColorRgba32 : IEquatable<ColorRgba32>
 	{
 		public byte r, g, b, a;
+
 		public ColorRgba32(byte r, byte g, byte b, byte a)
 		{
 			this.r = r;
 			this.g = g;
 			this.b = b;
 			this.a = a;
-		}
-
-		public ColorRgba32(Rgba32 color)
-		{
-			this.r = color.R;
-			this.g = color.G;
-			this.b = color.B;
-			this.a = color.A;
 		}
 
 		public bool Equals(ColorRgba32 other)
@@ -171,14 +163,11 @@ namespace BCnEncoder.Shared
 			);
 		}
 
+		public static implicit operator ColorRgba32(ColorRgb24 d) => new ColorRgba32(d.r, d.g, d.b, 255);
+
 		public override string ToString()
 		{
 			return $"r : {r} g : {g} b : {b} a : {a}";
-		}
-
-		public Rgba32 ToRgba32()
-		{
-			return new Rgba32(r, g, b, a);
 		}
 	}
 
@@ -222,17 +211,6 @@ namespace BCnEncoder.Shared
 			var fr = (float)rgba.r / 255;
 			var fg = (float)rgba.g / 255;
 			var fb = (float)rgba.b / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(Rgba32 rgb)
-		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
 
 			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
 			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
@@ -291,15 +269,6 @@ namespace BCnEncoder.Shared
 				left.y / right,
 				left.cb / right,
 				left.cr / right);
-		}
-
-		public Rgba32 ToRgba32()
-		{
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), 255);
 		}
 	}
 
@@ -476,7 +445,7 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	internal struct ColorRgb565 : IEquatable<ColorRgb565>
+	public struct ColorRgb565 : IEquatable<ColorRgb565>
 	{
 		public bool Equals(ColorRgb565 other)
 		{
@@ -511,45 +480,56 @@ namespace BCnEncoder.Shared
 
 		public ushort data;
 
-		public byte R {
-			readonly get {
+		public byte R
+		{
+			readonly get
+			{
 				var r5 = (data & RedMask) >> RedShift;
 				return (byte)((r5 << 3) | (r5 >> 2));
 			}
-			set {
+			set
+			{
 				var r5 = value >> 3;
 				data = (ushort)(data & ~RedMask);
 				data = (ushort)(data | (r5 << RedShift));
 			}
 		}
 
-		public byte G {
-			readonly get {
+		public byte G
+		{
+			readonly get
+			{
 				var g6 = (data & GreenMask) >> GreenShift;
 				return (byte)((g6 << 2) | (g6 >> 4));
 			}
-			set {
+			set
+			{
 				var g6 = value >> 2;
 				data = (ushort)(data & ~GreenMask);
 				data = (ushort)(data | (g6 << GreenShift));
 			}
 		}
 
-		public byte B {
-			readonly get {
+		public byte B
+		{
+			readonly get
+			{
 				var b5 = data & BlueMask;
 				return (byte)((b5 << 3) | (b5 >> 2));
 			}
-			set {
+			set
+			{
 				var b5 = value >> 3;
 				data = (ushort)(data & ~BlueMask);
 				data = (ushort)(data | b5);
 			}
 		}
 
-		public int RawR {
+		public int RawR
+		{
 			readonly get { return (data & RedMask) >> RedShift; }
-			set {
+			set
+			{
 				if (value > 31) value = 31;
 				if (value < 0) value = 0;
 				data = (ushort)(data & ~RedMask);
@@ -557,9 +537,11 @@ namespace BCnEncoder.Shared
 			}
 		}
 
-		public int RawG {
+		public int RawG
+		{
 			readonly get { return (data & GreenMask) >> GreenShift; }
-			set {
+			set
+			{
 				if (value > 63) value = 63;
 				if (value < 0) value = 0;
 				data = (ushort)(data & ~GreenMask);
@@ -567,9 +549,11 @@ namespace BCnEncoder.Shared
 			}
 		}
 
-		public int RawB {
+		public int RawB
+		{
 			readonly get { return data & BlueMask; }
-			set {
+			set
+			{
 				if (value > 31) value = 31;
 				if (value < 0) value = 0;
 				data = (ushort)(data & ~BlueMask);
@@ -585,14 +569,16 @@ namespace BCnEncoder.Shared
 			B = b;
 		}
 
-		public ColorRgb565(Vector3 colorVector) {
+		public ColorRgb565(Vector3 colorVector)
+		{
 			data = 0;
 			R = ByteHelper.ClampToByte(colorVector.X * 255);
 			G = ByteHelper.ClampToByte(colorVector.Y * 255);
 			B = ByteHelper.ClampToByte(colorVector.Z * 255);
 		}
 
-		public ColorRgb565(ColorRgb24 color) {
+		public ColorRgb565(ColorRgb24 color)
+		{
 			data = 0;
 			R = color.r;
 			G = color.g;
@@ -604,18 +590,21 @@ namespace BCnEncoder.Shared
 			return new ColorRgb24(R, G, B);
 		}
 
-		public override string ToString() {
+		public override string ToString()
+		{
 			return $"r : {R} g : {G} b : {B}";
 		}
 
-		public ColorRgba32 ToColorRgba32() {
+		public ColorRgba32 ToColorRgba32()
+		{
 			return new ColorRgba32(R, G, B, 255);
 		}
 	}
 
-	internal struct ColorRgb24 : IEquatable<ColorRgb24>
+	public struct ColorRgb24 : IEquatable<ColorRgb24>
 	{
 		public byte r, g, b;
+
 		public ColorRgb24(byte r, byte g, byte b)
 		{
 			this.r = r;
@@ -623,22 +612,18 @@ namespace BCnEncoder.Shared
 			this.b = b;
 		}
 
-		public ColorRgb24(ColorRgb565 color) {
+		public ColorRgb24(ColorRgb565 color)
+		{
 			this.r = color.R;
 			this.g = color.G;
 			this.b = color.B;
 		}
 
-		public ColorRgb24(ColorRgba32 color) {
+		public ColorRgb24(ColorRgba32 color)
+		{
 			this.r = color.r;
 			this.g = color.g;
 			this.b = color.b;
-		}
-
-		public ColorRgb24(Rgba32 color) {
-			this.r = color.R;
-			this.g = color.G;
-			this.b = color.B;
 		}
 
 		public bool Equals(ColorRgb24 other)
@@ -706,7 +691,8 @@ namespace BCnEncoder.Shared
 			);
 		}
 
-		public override string ToString() {
+		public override string ToString()
+		{
 			return $"r : {r} g : {g} b : {b}";
 		}
 	}
@@ -762,20 +748,9 @@ namespace BCnEncoder.Shared
 			alpha = rgba.a / 255f;
 		}
 
-		public ColorYCbCrAlpha(Rgba32 rgb)
+
+		public ColorRgb565 ToColorRgb565()
 		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-			alpha = rgb.A / 255f;
-		}
-
-
-		public ColorRgb565 ToColorRgb565() {
 			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
 			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
 			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
@@ -783,7 +758,8 @@ namespace BCnEncoder.Shared
 			return new ColorRgb565((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
 		}
 
-		public override string ToString() {
+		public override string ToString()
+		{
 			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
 			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
 			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
@@ -791,7 +767,8 @@ namespace BCnEncoder.Shared
 			return $"r : {r * 255} g : {g * 255} b : {b * 255}";
 		}
 
-		public float CalcDistWeighted(ColorYCbCrAlpha other, float yWeight = 4, float aWeight = 1) {
+		public float CalcDistWeighted(ColorYCbCrAlpha other, float yWeight = 4, float aWeight = 1)
+		{
 			var dy = (y - other.y) * (y - other.y) * yWeight;
 			var dcb = (cb - other.cb) * (cb - other.cb);
 			var dcr = (cr - other.cr) * (cr - other.cr);
@@ -800,7 +777,7 @@ namespace BCnEncoder.Shared
 			return MathF.Sqrt(dy + dcb + dcr + da);
 		}
 
-		public static ColorYCbCrAlpha operator+(ColorYCbCrAlpha left, ColorYCbCrAlpha right)
+		public static ColorYCbCrAlpha operator +(ColorYCbCrAlpha left, ColorYCbCrAlpha right)
 		{
 			return new ColorYCbCrAlpha(
 				left.y + right.y,
@@ -809,7 +786,7 @@ namespace BCnEncoder.Shared
 				left.alpha + right.alpha);
 		}
 
-		public static ColorYCbCrAlpha operator/(ColorYCbCrAlpha left, float right)
+		public static ColorYCbCrAlpha operator /(ColorYCbCrAlpha left, float right)
 		{
 			return new ColorYCbCrAlpha(
 				left.y / right,
@@ -817,32 +794,28 @@ namespace BCnEncoder.Shared
 				left.cr / right,
 				left.alpha / right);
 		}
-
-		public Rgba32 ToRgba32() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), (byte)(alpha * 255));
-		}
 	}
 
-	internal struct ColorXyz {
+	internal struct ColorXyz
+	{
 		public float x;
 		public float y;
 		public float z;
 
-		public ColorXyz(float x, float y, float z) {
+		public ColorXyz(float x, float y, float z)
+		{
 			this.x = x;
 			this.y = y;
 			this.z = z;
 		}
 
-		public ColorXyz(ColorRgb24 color) {
+		public ColorXyz(ColorRgb24 color)
+		{
 			this = ColorToXyz(color);
 		}
 
-		public static ColorXyz ColorToXyz(ColorRgb24 color) {
+		public static ColorXyz ColorToXyz(ColorRgb24 color)
+		{
 			var r = PivotRgb(color.r / 255.0f);
 			var g = PivotRgb(color.g / 255.0f);
 			var b = PivotRgb(color.b / 255.0f);
@@ -851,41 +824,44 @@ namespace BCnEncoder.Shared
 			return new ColorXyz(r * 0.4124f + g * 0.3576f + b * 0.1805f, r * 0.2126f + g * 0.7152f + b * 0.0722f, r * 0.0193f + g * 0.1192f + b * 0.9505f);
 		}
 
-		private static float PivotRgb(float n) {
+		private static float PivotRgb(float n)
+		{
 			return (n > 0.04045f ? MathF.Pow((n + 0.055f) / 1.055f, 2.4f) : n / 12.92f) * 100;
 		}
 	}
 
-	internal struct ColorLab {
+	internal struct ColorLab
+	{
 		public float l;
 		public float a;
 		public float b;
 
-		public ColorLab(float l, float a, float b) {
+		public ColorLab(float l, float a, float b)
+		{
 			this.l = l;
 			this.a = a;
 			this.b = b;
 		}
 
-		public ColorLab(ColorRgb24 color) {
+		public ColorLab(ColorRgb24 color)
+		{
 			this = ColorToLab(color);
 		}
 
-		public ColorLab(ColorRgba32 color) {
+		public ColorLab(ColorRgba32 color)
+		{
 			this = ColorToLab(new ColorRgb24(color.r, color.g, color.b));
 		}
 
-		public ColorLab(Rgba32 color) {
-			this = ColorToLab(new ColorRgb24(color.R, color.G, color.B));
-		}
-
-		public static ColorLab ColorToLab(ColorRgb24 color) {
+		public static ColorLab ColorToLab(ColorRgb24 color)
+		{
 			var xyz = new ColorXyz(color);
 			return XyzToLab(xyz);
 		}
 
 
-		public static ColorLab XyzToLab(ColorXyz xyz) {
+		public static ColorLab XyzToLab(ColorXyz xyz)
+		{
 			var refX = 95.047f; // Observer= 2°, Illuminant= D65
 			var refY = 100.000f;
 			var refZ = 108.883f;
@@ -897,7 +873,8 @@ namespace BCnEncoder.Shared
 			return new ColorLab(116 * y - 16, 500 * (x - y), 200 * (y - z));
 		}
 
-		private static float PivotXyz(float n) {
+		private static float PivotXyz(float n)
+		{
 			var i = MathF.Cbrt(n);
 			return n > 0.008856f ? i : 7.787f * n + 16 / 116f;
 		}

--- a/BCnEnc.Net/Shared/EncodedBlocks.cs
+++ b/BCnEnc.Net/Shared/EncodedBlocks.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
@@ -53,11 +52,11 @@ namespace BCnEncoder.Shared
 				var color = colors[colorIndex];
 				if (useAlpha && colorIndex == 3)
 				{
-					pixels[i] = new Rgba32(0, 0, 0, 0);
+					pixels[i] = new ColorRgba32(0, 0, 0, 0);
 				}
 				else
 				{
-					pixels[i] = new Rgba32(color.r, color.g, color.b, 255);
+					pixels[i] = new ColorRgba32(color.r, color.g, color.b, 255);
 				}
 			}
 			return output;
@@ -107,7 +106,7 @@ namespace BCnEncoder.Shared
 				var colorIndex = (int)((colorIndices >> (i * 2)) & 0b11);
 				var color = colors[colorIndex];
 
-				pixels[i] = new Rgba32(color.r, color.g, color.b, GetAlpha(i));
+				pixels[i] = new ColorRgba32(color.r, color.g, color.b, GetAlpha(i));
 			}
 			return output;
 		}
@@ -170,7 +169,7 @@ namespace BCnEncoder.Shared
 				var colorIndex = (int)((colorIndices >> (i * 2)) & 0b11);
 				var color = colors[colorIndex];
 
-				pixels[i] = new Rgba32(color.r, color.g, color.b, alphas[i]);
+				pixels[i] = new ColorRgba32(color.r, color.g, color.b, alphas[i]);
 			}
 			return output;
 		}
@@ -209,7 +208,7 @@ namespace BCnEncoder.Shared
 				for (var i = 0; i < pixels.Length; i++)
 				{
 					var index = GetComponentIndex(i);
-					pixels[i] = new Rgba32(reds[index], reds[index], reds[index], 255);
+					pixels[i] = new ColorRgba32(reds[index], reds[index], reds[index], 255);
 				}
 			}
 			else
@@ -217,7 +216,7 @@ namespace BCnEncoder.Shared
 				for (var i = 0; i < pixels.Length; i++)
 				{
 					var index = GetComponentIndex(i);
-					pixels[i] = new Rgba32(reds[index], 0, 0, 255);
+					pixels[i] = new ColorRgba32(reds[index], 0, 0, 255);
 				}
 			}
 
@@ -273,7 +272,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				pixels[i] = new Rgba32(reds[i], greens[i], 0, 255);
+				pixels[i] = new ColorRgba32(reds[i], greens[i], 0, 255);
 			}
 
 			return output;
@@ -319,7 +318,7 @@ namespace BCnEncoder.Shared
 
 				var color = this.color0.Mode == 0 ? color0.InterpolateThird(color1, colorIndex) : colors[colorIndex];
 
-				pixels[i] = new Rgba32(color.r, color.g, color.b, 255);
+				pixels[i] = new ColorRgba32(color.r, color.g, color.b, 255);
 			}
 			return output;
 		}
@@ -439,7 +438,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				pixels[i].A = alphas.GetAlpha(i);
+				pixels[i].a = alphas.GetAlpha(i);
 			}
 			return output;
 		}
@@ -460,7 +459,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				pixels[i].A = componentValues[i];
+				pixels[i].a = componentValues[i];
 			}
 			return output;
 		}

--- a/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace BCnEncoder.Shared
+namespace BCnEncoder.Shared.ImageFiles
 {
 	public class DdsFile
 	{

--- a/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
@@ -7,7 +7,7 @@ namespace BCnEncoder.Shared.ImageFiles
 	/// <summary>
 	/// The format identifier of an image file.
 	/// </summary>
-	public enum ImagefileFormat
+	public enum ImageFileFormat
 	{
 		/// <summary>
 		/// Represents the KTX image file format.
@@ -37,19 +37,19 @@ namespace BCnEncoder.Shared.ImageFiles
 		/// </summary>
 		/// <param name="stream">The stream of data to identify.</param>
 		/// <returns>The format this image file may contain.</returns>
-		public static ImagefileFormat DetermineImageFormat(Stream stream)
+		public static ImageFileFormat DetermineImageFormat(Stream stream)
 		{
 			if (IsDds(stream))
 			{
-				return ImagefileFormat.Dds;
+				return ImageFileFormat.Dds;
 			}
 
 			if (IsKtx(stream))
 			{
-				return ImagefileFormat.Ktx;
+				return ImageFileFormat.Ktx;
 			}
 
-			return ImagefileFormat.Unknown;
+			return ImageFileFormat.Unknown;
 		}
 
 		private static bool IsDds(Stream stream)

--- a/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace BCnEncoder.Shared.ImageFiles
+{
+	/// <summary>
+	/// The format identifier of an image file.
+	/// </summary>
+	public enum ImagefileFormat
+	{
+		/// <summary>
+		/// Represents the KTX image file format.
+		/// </summary>
+		Ktx,
+
+		/// <summary>
+		/// Represents the DDS image file format.
+		/// </summary>
+		Dds,
+
+		/// <summary>
+		/// Represents an unknown image file format.
+		/// </summary>
+		Unknown
+	}
+
+	/// <summary>
+	/// Static helper class to determine the format of an image file.
+	/// </summary>
+	public static class ImageFile
+	{
+		private static readonly byte[] ktx1Identifier = { 0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A };
+
+		/// <summary>
+		/// Determines the image file format of the given stream.
+		/// </summary>
+		/// <param name="stream">The stream of data to identify.</param>
+		/// <returns>The format this image file may contain.</returns>
+		public static ImagefileFormat DetermineImageFormat(Stream stream)
+		{
+			if (IsDds(stream))
+			{
+				return ImagefileFormat.Dds;
+			}
+
+			if (IsKtx(stream))
+			{
+				return ImagefileFormat.Ktx;
+			}
+
+			return ImagefileFormat.Unknown;
+		}
+
+		private static bool IsDds(Stream stream)
+		{
+			using var br = new BinaryReader(stream, Encoding.UTF8, true);
+
+			var magic = br.ReadUInt32();
+			stream.Position -= 4;
+
+			return magic == 0x20534444U;
+		}
+
+		private static bool IsKtx(Stream stream)
+		{
+			// Only checks for version 1
+			using var br = new BinaryReader(stream, Encoding.ASCII, true);
+
+			var identifier = br.ReadBytes(12);
+			stream.Position -= 12;
+
+			return identifier.SequenceEqual(ktx1Identifier);
+		}
+	}
+}

--- a/BCnEnc.Net/Shared/ImageFiles/KtxFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/KtxFile.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using static System.Text.Encoding;
 
-namespace BCnEncoder.Shared
+namespace BCnEncoder.Shared.ImageFiles
 {
 	/// <summary>
 	/// A representation of a ktx file.

--- a/BCnEnc.Net/Shared/ImageQuality.cs
+++ b/BCnEnc.Net/Shared/ImageQuality.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using SixLabors.ImageSharp.PixelFormats;
+using System;
 
 namespace BCnEncoder.Shared
 {
 	public class ImageQuality
 	{
-		public static float PeakSignalToNoiseRatio(ReadOnlySpan<Rgba32> original, ReadOnlySpan<Rgba32> other, bool countAlpha = true) {
+		public static float PeakSignalToNoiseRatio(ReadOnlySpan<ColorRgba32> original, ReadOnlySpan<ColorRgba32> other, bool countAlpha = true) {
 			if (original.Length != other.Length) {
 				throw new ArgumentException("Both spans should be the same length");
 			}
@@ -17,7 +16,7 @@ namespace BCnEncoder.Shared
 				error += (o.cb - c.cb) * (o.cb - c.cb);
 				error += (o.cr - c.cr) * (o.cr - c.cr);
 				if (countAlpha) {
-					error += (original[i].A - other[i].A) / 255.0f * ((original[i].A - other[i].A) / 255.0f);
+					error += (original[i].a - other[i].a) / 255.0f * ((original[i].a - other[i].a) / 255.0f);
 				}
 				
 			}
@@ -35,7 +34,7 @@ namespace BCnEncoder.Shared
 			return 20 * MathF.Log10(1 / MathF.Sqrt(error));
 		}
 
-		public static float PeakSignalToNoiseRatioLuminance(ReadOnlySpan<Rgba32> original, ReadOnlySpan<Rgba32> other, bool countAlpha = true) {
+		public static float PeakSignalToNoiseRatioLuminance(ReadOnlySpan<ColorRgba32> original, ReadOnlySpan<ColorRgba32> other, bool countAlpha = true) {
 			if (original.Length != other.Length) {
 				throw new ArgumentException("Both spans should be the same length");
 			}
@@ -45,7 +44,7 @@ namespace BCnEncoder.Shared
 				var c = new ColorYCbCr(other[i]);
 				error += (o.y - c.y) * (o.y - c.y);
 				if (countAlpha) {
-					error += (original[i].A - other[i].A) / 255.0f * ((original[i].A - other[i].A) / 255.0f);
+					error += (original[i].a - other[i].a) / 255.0f * ((original[i].a - other[i].a) / 255.0f);
 				}
 				
 			}

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -6,6 +6,51 @@ namespace BCnEncoder.Shared
 {
 	internal static class ImageToBlocks
 	{
+		#region Blocks to colors
+
+		internal static ColorRgba32[] ColorsFromRawBlocks(RawBlock4X4Rgba32[,] blocks, int pixelWidth, int pixelHeight)
+		{
+			var output = new ColorRgba32[pixelWidth * pixelHeight];
+
+			for (var y = 0; y < pixelHeight; y++)
+			{
+				for (var x = 0; x < pixelWidth; x++)
+				{
+					var blockIndexX = x >> 2;
+					var blockIndexY = y >> 2;
+					var blockInternalIndexX = x & 3;
+					var blockInternalIndexY = y & 3;
+
+					output[x + y * pixelWidth] = blocks[blockIndexX, blockIndexY][blockInternalIndexX, blockInternalIndexY];
+				}
+			}
+
+			return output;
+		}
+
+		internal static ColorRgba32[] ColorsFromRawBlocks(RawBlock4X4Rgba32[] blocks, int pixelWidth, int pixelHeight)
+		{
+			var output = new ColorRgba32[pixelWidth * pixelHeight];
+
+			for (var y = 0; y < pixelHeight; y++)
+			{
+				for (var x = 0; x < pixelWidth; x++)
+				{
+					var blockIndexX = x >> 2;
+					var blockIndexY = y >> 2;
+					var blockInternalIndexX = x & 3;
+					var blockInternalIndexY = y & 3;
+
+					var blockIndex = blockIndexX + blockIndexY * 4;
+
+					output[x + y * pixelWidth] = blocks[blockIndex][blockInternalIndexX, blockInternalIndexY];
+				}
+			}
+
+			return output;
+		}
+
+		#endregion
 
 		internal static RawBlock4X4Rgba32[] ImageTo4X4(ImageFrame<Rgba32> image, out int blocksWidth, out int blocksHeight)
 		{
@@ -65,66 +110,6 @@ namespace BCnEncoder.Shared
 						}
 					}
 					output[blocksWidth - 1 + i * blocksWidth] = lastBlock;
-				}
-			}
-
-			return output;
-		}
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[,] blocks, int blocksWidth, int blocksHeight)
-			=> ImageFromRawBlocks(blocks, blocksWidth, blocksHeight, blocksWidth * 4, blocksHeight * 4);
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[,] blocks, int blocksWidth, int blocksHeight, int pixelWidth, int pixelHeight)
-		{
-			var output = new Image<Rgba32>(pixelWidth, pixelHeight);
-
-			if (!output.TryGetSinglePixelSpan(out var pixels))
-			{
-				throw new Exception("Cannot get pixel span.");
-			}
-
-			for (var y = 0; y < output.Height; y++)
-			{
-				for (var x = 0; x < output.Width; x++)
-				{
-					var blockIndexX = x >> 2;
-					var blockIndexY = y >> 2;
-					var blockInternalIndexX = x & 3;
-					var blockInternalIndexY = y & 3;
-
-					pixels[x + y * output.Width] =
-						blocks[blockIndexX, blockIndexY]
-							[blockInternalIndexX, blockInternalIndexY];
-				}
-			}
-
-			return output;
-		}
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[] blocks, int blocksWidth, int blocksHeight)
-			=> ImageFromRawBlocks(blocks, blocksWidth, blocksHeight, blocksWidth * 4, blocksHeight * 4);
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[] blocks, int blocksWidth, int blocksHeight, int pixelWidth, int pixelHeight)
-		{
-			var output = new Image<Rgba32>(pixelWidth, pixelHeight);
-
-			if (!output.TryGetSinglePixelSpan(out var pixels))
-			{
-				throw new Exception("Cannot get pixel span.");
-			}
-
-			for (var y = 0; y < output.Height; y++)
-			{
-				for (var x = 0; x < output.Width; x++)
-				{
-					var blockIndexX = x >> 2;
-					var blockIndexY = y >> 2;
-					var blockInternalIndexX = x & 3;
-					var blockInternalIndexY = y & 3;
-
-					pixels[x + y * output.Width] =
-						blocks[blockIndexX + blockIndexY * blocksWidth]
-							[blockInternalIndexX, blockInternalIndexY];
 				}
 			}
 

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -64,7 +64,7 @@ namespace BCnEncoder.Shared
 			{
 				for (var x = 0; x < image.Width; x++)
 				{
-					var color = span[x, y];
+					var color = span[y, x];
 
 					var blockIndexX = x >> 2;
 					var blockIndexY = y >> 2;

--- a/BCnEnc.Net/Shared/LinearClustering.cs
+++ b/BCnEnc.Net/Shared/LinearClustering.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
@@ -121,7 +120,7 @@ namespace BCnEncoder.Shared
 		/// the more spatial proximity is emphasized and the more compact the cluster,
 		/// M should be in range of 1 to 20.
 		/// </summary>
-		public static int[] ClusterPixels(ReadOnlySpan<Rgba32> pixels, int width, int height,
+		public static int[] ClusterPixels(ReadOnlySpan<ColorRgba32> pixels, int width, int height,
 			int clusters, float m = 10, int maxIterations = 10, bool enforceConnectivity = true)
 		{
 
@@ -292,7 +291,7 @@ namespace BCnEncoder.Shared
 			return clusterCenters;
 		}
 
-		private static LabXy[] ConvertToLabXy(ReadOnlySpan<Rgba32> pixels, int width, int height)
+		private static LabXy[] ConvertToLabXy(ReadOnlySpan<ColorRgba32> pixels, int width, int height)
 		{
 			var labXys = new LabXy[pixels.Length];
 			//Convert pixels to LabXy
@@ -302,7 +301,7 @@ namespace BCnEncoder.Shared
 				{
 					var i = x + y * width;
 					var lab = new ColorLab(pixels[i]);
-					labXys[i] = new LabXy()
+					labXys[i] = new LabXy
 					{
 						l = lab.l,
 						a = lab.a,

--- a/BCnEnc.Net/Shared/PcaVectors.cs
+++ b/BCnEnc.Net/Shared/PcaVectors.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Numerics;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
@@ -9,14 +8,14 @@ namespace BCnEncoder.Shared
 		private const int C565_5Mask = 0xF8;
 		private const int C565_6Mask = 0xFC;
 
-		private static void ConvertToVector4(ReadOnlySpan<Rgba32> colors, Span<Vector4> vectors)
+		private static void ConvertToVector4(ReadOnlySpan<ColorRgba32> colors, Span<Vector4> vectors)
 		{
 			for (var i = 0; i < colors.Length; i++)
 			{
-				vectors[i].X += colors[i].R / 255f;
-				vectors[i].Y += colors[i].G / 255f;
-				vectors[i].Z += colors[i].B / 255f;
-				vectors[i].W += colors[i].A / 255f;
+				vectors[i].X += colors[i].r / 255f;
+				vectors[i].Y += colors[i].g / 255f;
+				vectors[i].Z += colors[i].b / 255f;
+				vectors[i].W += colors[i].a / 255f;
 			}
 		}
 
@@ -110,7 +109,7 @@ namespace BCnEncoder.Shared
 			return lastDa;
 		}
 
-		public static void Create(Span<Rgba32> colors, out Vector3 mean, out Vector3 principalAxis)
+		public static void Create(Span<ColorRgba32> colors, out Vector3 mean, out Vector3 principalAxis)
 		{
 			Span<Vector4> vectors = stackalloc Vector4[colors.Length];
 			ConvertToVector4(colors, vectors);
@@ -130,7 +129,7 @@ namespace BCnEncoder.Shared
 
 		}
 
-		public static void CreateWithAlpha(Span<Rgba32> colors, out Vector4 mean, out Vector4 principalAxis)
+		public static void CreateWithAlpha(Span<ColorRgba32> colors, out Vector4 mean, out Vector4 principalAxis)
 		{
 			Span<Vector4> vectors = stackalloc Vector4[colors.Length];
 			ConvertToVector4(colors, vectors);
@@ -140,7 +139,7 @@ namespace BCnEncoder.Shared
 		}
 
 
-		public static void GetExtremePoints(Span<Rgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb24 min,
+		public static void GetExtremePoints(Span<ColorRgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb24 min,
 			out ColorRgb24 max)
 		{
 
@@ -149,7 +148,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < colors.Length; i++)
 			{
-				var colorVec = new Vector3(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f);
+				var colorVec = new Vector3(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f);
 
 				var v = colorVec - mean;
 				var d = Vector3.Dot(v, principalAxis);
@@ -180,7 +179,7 @@ namespace BCnEncoder.Shared
 			max = new ColorRgb24((byte)maxR, (byte)maxG, (byte)maxB);
 		}
 
-		public static void GetMinMaxColor565(Span<Rgba32> colors, Vector3 mean, Vector3 principalAxis, 
+		public static void GetMinMaxColor565(Span<ColorRgba32> colors, Vector3 mean, Vector3 principalAxis, 
 			out ColorRgb565 min, out ColorRgb565 max)
 		{
 
@@ -189,7 +188,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < colors.Length; i++)
 			{
-				var colorVec = new Vector3(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f);
+				var colorVec = new Vector3(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f);
 
 				var v = colorVec - mean;
 				var d = Vector3.Dot(v, principalAxis);
@@ -234,7 +233,7 @@ namespace BCnEncoder.Shared
 
 		}
 
-		public static void GetExtremePointsWithAlpha(Span<Rgba32> colors, Vector4 mean, Vector4 principalAxis, out Vector4 min,
+		public static void GetExtremePointsWithAlpha(Span<ColorRgba32> colors, Vector4 mean, Vector4 principalAxis, out Vector4 min,
 			out Vector4 max)
 		{
 
@@ -243,7 +242,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < colors.Length; i++)
 			{
-				var colorVec = new Vector4(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f, colors[i].A / 255f);
+				var colorVec = new Vector4(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f, colors[i].a / 255f);
 
 				var v = colorVec - mean;
 				var d = Vector4.Dot(v, principalAxis);
@@ -255,14 +254,14 @@ namespace BCnEncoder.Shared
 			max = mean + principalAxis * maxD;
 		}
 
-		public static void GetOptimizedEndpoints565(Span<Rgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb565 min, out ColorRgb565 max,
+		public static void GetOptimizedEndpoints565(Span<ColorRgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb565 min, out ColorRgb565 max,
 			float rWeight = 0.3f, float gWeight = 0.6f, float bWeight = 0.1f)
 		{
 			var length = colors.Length;
 			var vectorColors = new Vector3[length];
 			for (var i = 0; i < colors.Length; i++)
 			{
-				vectorColors[i] = new Vector3(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f);
+				vectorColors[i] = new Vector3(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f);
 			}
 
 			float minD = 0;

--- a/BCnEnc.Net/Shared/RawBlocks.cs
+++ b/BCnEnc.Net/Shared/RawBlocks.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {

--- a/BCnEnc.Net/Shared/RawBlocks.cs
+++ b/BCnEnc.Net/Shared/RawBlocks.cs
@@ -1,45 +1,51 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
 
-	internal struct RawBlock4X4Rgba32 {
-		public Rgba32 p00, p10, p20, p30;
-		public Rgba32 p01, p11, p21, p31;
-		public Rgba32 p02, p12, p22, p32;
-		public Rgba32 p03, p13, p23, p33;
-		public Span<Rgba32> AsSpan => MemoryMarshal.CreateSpan(ref p00, 16);
+	public struct RawBlock4X4Rgba32
+	{
+		public ColorRgba32 p00, p10, p20, p30;
+		public ColorRgba32 p01, p11, p21, p31;
+		public ColorRgba32 p02, p12, p22, p32;
+		public ColorRgba32 p03, p13, p23, p33;
+		public Span<ColorRgba32> AsSpan => MemoryMarshal.CreateSpan(ref p00, 16);
 
-		public Rgba32 this[int x, int y] {
+		public ColorRgba32 this[int x, int y]
+		{
 			get => AsSpan[x + y * 4];
 			set => AsSpan[x + y * 4] = value;
 		}
 
-		public Rgba32 this[int index] {
+		public ColorRgba32 this[int index]
+		{
 			get => AsSpan[index];
 			set => AsSpan[index] = value;
 		}
 
-		public int CalculateError(RawBlock4X4Rgba32 other, bool useAlpha = false) {
+		public int CalculateError(RawBlock4X4Rgba32 other, bool useAlpha = false)
+		{
 			float error = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = pix1[i];
 				var col2 = pix2[i];
 
-				var re = col1.R - col2.R;
-				var ge = col1.G - col2.G;
-				var be = col1.B - col2.B;
+				var re = col1.r - col2.r;
+				var ge = col1.g - col2.g;
+				var be = col1.b - col2.b;
 
 				error += re * re;
 				error += ge * ge;
 				error += be * be;
 
-				if (useAlpha) {
-					var ae = col1.A - col2.A;
+				if (useAlpha)
+				{
+					var ae = col1.a - col2.a;
 					error += ae * ae * 4;
 				}
 			}
@@ -50,13 +56,15 @@ namespace BCnEncoder.Shared
 			return (int)error;
 		}
 
-		public float CalculateYCbCrError(RawBlock4X4Rgba32 other) {
+		public float CalculateYCbCrError(RawBlock4X4Rgba32 other)
+		{
 			float yError = 0;
 			float cbError = 0;
 			float crError = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = new ColorYCbCr(pix1[i]);
 				var col2 = new ColorYCbCr(pix2[i]);
 
@@ -74,14 +82,16 @@ namespace BCnEncoder.Shared
 			return error;
 		}
 
-		public float CalculateYCbCrAlphaError(RawBlock4X4Rgba32 other, float yMultiplier = 2, float alphaMultiplier = 1) {
+		public float CalculateYCbCrAlphaError(RawBlock4X4Rgba32 other, float yMultiplier = 2, float alphaMultiplier = 1)
+		{
 			float yError = 0;
 			float cbError = 0;
 			float crError = 0;
 			float alphaError = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = new ColorYCbCrAlpha(pix1[i]);
 				var col2 = new ColorYCbCrAlpha(pix2[i]);
 
@@ -100,45 +110,53 @@ namespace BCnEncoder.Shared
 			return error;
 		}
 
-		public RawBlock4X4Ycbcr ToRawBlockYcbcr() {
+		public RawBlock4X4Ycbcr ToRawBlockYcbcr()
+		{
 			var rawYcbcr = new RawBlock4X4Ycbcr();
 			var pixels = AsSpan;
 			var ycbcrPs = rawYcbcr.AsSpan;
-			for (var i = 0; i < pixels.Length; i++) {
+			for (var i = 0; i < pixels.Length; i++)
+			{
 				ycbcrPs[i] = new ColorYCbCr(pixels[i]);
 			}
 			return rawYcbcr;
 		}
 
-		public bool HasTransparentPixels() {
+		public bool HasTransparentPixels()
+		{
 			var pixels = AsSpan;
-			for (var i = 0; i < pixels.Length; i++) {
-				if (pixels[i].A < 255) return true;
+			for (var i = 0; i < pixels.Length; i++)
+			{
+				if (pixels[i].a < 255) return true;
 			}
 			return false;
 		}
 	}
 
 
-	internal struct RawBlock4X4Ycbcr {
+	public struct RawBlock4X4Ycbcr
+	{
 		public ColorYCbCr p00, p10, p20, p30;
 		public ColorYCbCr p01, p11, p21, p31;
 		public ColorYCbCr p02, p12, p22, p32;
 		public ColorYCbCr p03, p13, p23, p33;
 		public Span<ColorYCbCr> AsSpan => MemoryMarshal.CreateSpan(ref p00, 16);
 
-		public ColorYCbCr this[int x, int y] {
+		public ColorYCbCr this[int x, int y]
+		{
 			get => AsSpan[x + y * 4];
 			set => AsSpan[x + y * 4] = value;
 		}
 
-		public float CalculateError(RawBlock4X4Rgba32 other) {
+		public float CalculateError(RawBlock4X4Rgba32 other)
+		{
 			float yError = 0;
 			float cbError = 0;
 			float crError = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = pix1[i];
 				var col2 = new ColorYCbCr(pix2[i]);
 

--- a/BCnEnc.Net/Shared/RgbBoundingBox.cs
+++ b/BCnEnc.Net/Shared/RgbBoundingBox.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using SixLabors.ImageSharp.PixelFormats;
+using System;
 
 namespace BCnEncoder.Shared
 {
@@ -11,7 +10,7 @@ namespace BCnEncoder.Shared
 	internal static class RgbBoundingBox
 	{
 
-		public static void Create565(ReadOnlySpan<Rgba32> colors, out ColorRgb565 min, out ColorRgb565 max)
+		public static void Create565(ReadOnlySpan<ColorRgba32> colors, out ColorRgb565 min, out ColorRgb565 max)
 		{
 			const int colorInsetShift = 4;
 			const int c5655Mask = 0xF8;
@@ -28,13 +27,13 @@ namespace BCnEncoder.Shared
 			{
 				var c = colors[i];
 
-				if (c.R < minR) minR = c.R;
-				if (c.G < minG) minG = c.G;
-				if (c.B < minB) minB = c.B;
+				if (c.r < minR) minR = c.r;
+				if (c.g < minG) minG = c.g;
+				if (c.b < minB) minB = c.b;
 
-				if (c.R > maxR) maxR = c.R;
-				if (c.G > maxG) maxG = c.G;
-				if (c.B > maxB) maxB = c.B;
+				if (c.r > maxR) maxR = c.r;
+				if (c.g > maxG) maxG = c.g;
+				if (c.b > maxB) maxB = c.b;
 			}
 
 			var insetR = (maxR - minR) >> colorInsetShift;
@@ -71,7 +70,7 @@ namespace BCnEncoder.Shared
 			max = new ColorRgb565((byte)maxR, (byte)maxG, (byte)maxB);
 		}
 
-		public static void Create565AlphaCutoff(ReadOnlySpan<Rgba32> colors, out ColorRgb565 min, out ColorRgb565 max, int alphaCutoff = 128)
+		public static void Create565AlphaCutoff(ReadOnlySpan<ColorRgba32> colors, out ColorRgb565 min, out ColorRgb565 max, int alphaCutoff = 128)
 		{
 			const int colorInsetShift = 4;
 			const int c5655Mask = 0xF8;
@@ -87,14 +86,14 @@ namespace BCnEncoder.Shared
 			for (var i = 0; i < colors.Length; i++)
 			{
 				var c = colors[i];
-				if (c.A < alphaCutoff) continue;
-				if (c.R < minR) minR = c.R;
-				if (c.G < minG) minG = c.G;
-				if (c.B < minB) minB = c.B;
+				if (c.a < alphaCutoff) continue;
+				if (c.r < minR) minR = c.r;
+				if (c.g < minG) minG = c.g;
+				if (c.b < minB) minB = c.b;
 
-				if (c.R > maxR) maxR = c.R;
-				if (c.G > maxG) maxG = c.G;
-				if (c.B > maxB) maxB = c.B;
+				if (c.r > maxR) maxR = c.r;
+				if (c.g > maxG) maxG = c.g;
+				if (c.b > maxB) maxB = c.b;
 			}
 
 			var insetR = (maxR - minR) >> colorInsetShift;
@@ -129,7 +128,7 @@ namespace BCnEncoder.Shared
 			max = new ColorRgb565((byte)maxR, (byte)maxG, (byte)maxB);
 		}
 
-		public static void Create565A(ReadOnlySpan<Rgba32> colors, out ColorRgb565 min, out ColorRgb565 max, out byte minAlpha, out byte maxAlpha)
+		public static void Create565A(ReadOnlySpan<ColorRgba32> colors, out ColorRgb565 min, out ColorRgb565 max, out byte minAlpha, out byte maxAlpha)
 		{
 			const int colorInsetShift = 4;
 			const int alphaInsetShift = 5;
@@ -148,15 +147,15 @@ namespace BCnEncoder.Shared
 			for (var i = 0; i < colors.Length; i++)
 			{
 				var c = colors[i];
-				if (c.R < minR) minR = c.R;
-				if (c.G < minG) minG = c.G;
-				if (c.B < minB) minB = c.B;
-				if (c.A < minA) minA = c.A;
+				if (c.r < minR) minR = c.r;
+				if (c.g < minG) minG = c.g;
+				if (c.b < minB) minB = c.b;
+				if (c.a < minA) minA = c.a;
 
-				if (c.R > maxR) maxR = c.R;
-				if (c.G > maxG) maxG = c.G;
-				if (c.B > maxB) maxB = c.B;
-				if (c.A > maxA) maxA = c.A;
+				if (c.r > maxR) maxR = c.r;
+				if (c.g > maxG) maxG = c.g;
+				if (c.b > maxB) maxB = c.b;
+				if (c.a > maxA) maxA = c.a;
 			}
 
 

--- a/BCnEncTests/Support/TestHelper.cs
+++ b/BCnEncTests/Support/TestHelper.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;


### PR DESCRIPTION
This PR removes ImageSharp completely as a dependency to BCnEncoder, in preparation for version 2.0.