### PR TITLE
Remove ImageSharp dependency completely

### DIFF
--- a/BCnEnc.Net/BCnEncoder.csproj
+++ b/BCnEnc.Net/BCnEncoder.csproj
@@ -45,7 +45,6 @@ Supported formats are:
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.0.0-preview4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/BCnEnc.Net/Decoder/BcBlockDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcBlockDecoder.cs
@@ -109,24 +109,33 @@ namespace BCnEncoder.Decoder
 
 	internal class Bc4Decoder : BaseBcBlockDecoder<Bc4Block>
 	{
-		private readonly bool redAsLuminance;
+		private readonly Bc4Component component;
 
-		public Bc4Decoder(bool redAsLuminance)
+		public Bc4Decoder(Bc4Component component)
 		{
-			this.redAsLuminance = redAsLuminance;
+			this.component = component;
 		}
 
 		protected override RawBlock4X4Rgba32 DecodeBlock(Bc4Block block)
 		{
-			return block.Decode(redAsLuminance);
+			return block.Decode(component);
 		}
 	}
 
 	internal class Bc5Decoder : BaseBcBlockDecoder<Bc5Block>
 	{
+		private readonly Bc4Component component1;
+		private readonly Bc4Component component2;
+
+		public Bc5Decoder(Bc4Component component1, Bc4Component component2)
+		{
+			this.component1 = component1;
+			this.component2 = component2;
+		}
+
 		protected override RawBlock4X4Rgba32 DecodeBlock(Bc5Block block)
 		{
-			return block.Decode();
+			return block.Decode(component1, component2);
 		}
 	}
 

--- a/BCnEnc.Net/Decoder/BcBlockDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcBlockDecoder.cs
@@ -11,6 +11,7 @@ namespace BCnEncoder.Decoder
 	internal interface IBcBlockDecoder
 	{
 		RawBlock4X4Rgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context);
+		RawBlock4X4Rgba32 DecodeBlock(ReadOnlySpan<byte> data);
 	}
 
 	internal abstract class BaseBcBlockDecoder<T> : IBcBlockDecoder where T : unmanaged
@@ -63,6 +64,12 @@ namespace BCnEncoder.Decoder
 			}
 
 			return output;
+		}
+
+		public RawBlock4X4Rgba32 DecodeBlock(ReadOnlySpan<byte> data)
+		{
+			var encodedBlock = MemoryMarshal.Cast<byte, T>(data)[0];
+			return DecodeBlock(encodedBlock);
 		}
 
 		protected abstract RawBlock4X4Rgba32 DecodeBlock(T block);

--- a/BCnEnc.Net/Decoder/BcDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcDecoder.cs
@@ -457,14 +457,14 @@ namespace BCnEncoder.Decoder
 
 			Span<byte> input = stackalloc byte[16];
 			input = input.Slice(0, GetBlockSize(format));
-			
+
 			var bytesRead = inputStream.Read(input);
 
 			if (bytesRead == 0)
 			{
 				return 0; //End of stream
 			}
-			
+
 			if (bytesRead != input.Length)
 			{
 				throw new Exception("Input stream does not have enough data available for a full block.");
@@ -490,32 +490,32 @@ namespace BCnEncoder.Decoder
 			switch (format)
 			{
 				case ImageFileFormat.Dds:
-				{
-					var file = DdsFile.Load(stream);
-					var decoded = DecodeInternal(file, allMipMaps, token);
-					var mem2Ds = new Memory2D<ColorRgba32>[decoded.Length];
-					for (var i = 0; i < decoded.Length; i++)
 					{
-						var mip = file.Faces[0].MipMaps[i];
-						mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int) mip.Height, (int) mip.Width);
-					}
+						var file = DdsFile.Load(stream);
+						var decoded = DecodeInternal(file, allMipMaps, token);
+						var mem2Ds = new Memory2D<ColorRgba32>[decoded.Length];
+						for (var i = 0; i < decoded.Length; i++)
+						{
+							var mip = file.Faces[0].MipMaps[i];
+							mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int)mip.Height, (int)mip.Width);
+						}
 
-					return mem2Ds;
-				}
+						return mem2Ds;
+					}
 
 				case ImageFileFormat.Ktx:
-				{
-					var file = KtxFile.Load(stream);
-					var decoded = DecodeInternal(file, allMipMaps, token);
-					var mem2Ds = new Memory2D<ColorRgba32>[decoded.Length];
-					for (var i = 0; i < decoded.Length; i++)
 					{
-						var mip = file.MipMaps[i];
-						mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int) mip.Height, (int) mip.Width);
-					}
+						var file = KtxFile.Load(stream);
+						var decoded = DecodeInternal(file, allMipMaps, token);
+						var mem2Ds = new Memory2D<ColorRgba32>[decoded.Length];
+						for (var i = 0; i < decoded.Length; i++)
+						{
+							var mip = file.MipMaps[i];
+							mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int)mip.Height, (int)mip.Width);
+						}
 
-					return mem2Ds;
-				}
+						return mem2Ds;
+					}
 
 				default:
 					throw new InvalidOperationException("Unknown image format.");
@@ -550,7 +550,7 @@ namespace BCnEncoder.Decoder
 			if (IsSupportedRawFormat(file.header.GlInternalFormat))
 			{
 				var decoder = GetRawDecoder(file.header.GlInternalFormat);
-				
+
 				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.MipMaps[mip].Faces[0].Data;
@@ -567,7 +567,7 @@ namespace BCnEncoder.Decoder
 				{
 					throw new NotSupportedException($"This Format is not supported: {file.header.GlInternalFormat}");
 				}
-				
+
 				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.MipMaps[mip].Faces[0].Data;
@@ -613,7 +613,7 @@ namespace BCnEncoder.Decoder
 			if (IsSupportedRawFormat(file))
 			{
 				var decoder = GetRawDecoder(file);
-				
+
 				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.Faces[0].MipMaps[mip].Data;
@@ -634,7 +634,7 @@ namespace BCnEncoder.Decoder
 				{
 					throw new NotSupportedException($"This Format is not supported: {format}");
 				}
-				
+
 				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.Faces[0].MipMaps[mip].Data;
@@ -787,10 +787,10 @@ namespace BCnEncoder.Decoder
 					return new Bc3Decoder();
 
 				case CompressionFormat.Bc4:
-					return new Bc4Decoder(OutputOptions.RedAsLuminance);
+					return new Bc4Decoder(OutputOptions.Bc4Component);
 
 				case CompressionFormat.Bc5:
-					return new Bc5Decoder();
+					return new Bc5Decoder(OutputOptions.Bc5Component1, OutputOptions.Bc5Component2);
 
 				case CompressionFormat.Bc7:
 					return new Bc7Decoder();

--- a/BCnEnc.Net/Decoder/BcDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcDecoder.cs
@@ -33,7 +33,7 @@ namespace BCnEncoder.Decoder
 		#region Async Api
 
 		/// <summary>
-		/// DecodeInternal raw encoded image asynchronously.
+		/// Decode raw encoded image asynchronously.
 		/// </summary>
 		/// <param name="inputStream">The stream containing the encoded data.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
@@ -41,7 +41,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[]> DecodeRawAsync(Stream inputStream, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>> DecodeRawAsync(Stream inputStream, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
 		{
 			var dataArray = new byte[GetBufferSize(format, pixelWidth, pixelHeight)];
 			inputStream.Read(dataArray, 0, dataArray.Length);
@@ -50,7 +50,7 @@ namespace BCnEncoder.Decoder
 		}
 
 		/// <summary>
-		/// DecodeInternal raw encoded image data asynchronously.
+		/// Decode raw encoded image data asynchronously.
 		/// </summary>
 		/// <param name="input">The <see cref="ReadOnlyMemory{T}"/> containing the encoded data.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
@@ -58,7 +58,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[]> DecodeRawAsync(ReadOnlyMemory<byte> input, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>> DecodeRawAsync(ReadOnlyMemory<byte> input, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeRawInternal(input, pixelWidth, pixelHeight, format, token), token);
 		}
@@ -69,7 +69,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="inputStream">The stream containing a Ktx or Dds file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[]> DecodeAsync(Stream inputStream, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>> DecodeAsync(Stream inputStream, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(inputStream, false, token)[0], token);
 		}
@@ -80,7 +80,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="inputStream">The stream containing a Ktx or Dds file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[][]> DecodeAllMipMapsAsync(Stream inputStream, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>[]> DecodeAllMipMapsAsync(Stream inputStream, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(inputStream, true, token), token);
 		}
@@ -91,7 +91,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[]> DecodeAsync(KtxFile file, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>> DecodeAsync(KtxFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, false, token)[0], token);
 		}
@@ -102,7 +102,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[][]> DecodeAllMipMapsAsync(KtxFile file, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>[]> DecodeAllMipMapsAsync(KtxFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, true, token), token);
 		}
@@ -113,7 +113,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Dds file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[]> DecodeAsync(DdsFile file, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>> DecodeAsync(DdsFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, false, token)[0], token);
 		}
@@ -124,7 +124,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Dds file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<ColorRgba32[][]> DecodeAllMipMapsAsync(DdsFile file, CancellationToken token = default)
+		public Task<ReadOnlyMemory<ColorRgba32>[]> DecodeAllMipMapsAsync(DdsFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, true, token), token);
 		}
@@ -134,14 +134,14 @@ namespace BCnEncoder.Decoder
 		#region Sync API
 
 		/// <summary>
-		/// DecodeInternal raw encoded image data.
+		/// Decode raw encoded image data.
 		/// </summary>
 		/// <param name="inputStream">The stream containing the encoded data.</param>
 		/// <param name="pixelWidth">The pixelWidth of the image.</param>
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public ColorRgba32[] DecodeRaw(Stream inputStream, int pixelWidth, int pixelHeight, CompressionFormat format)
+		public ReadOnlyMemory<ColorRgba32> DecodeRaw(Stream inputStream, int pixelWidth, int pixelHeight, CompressionFormat format)
 		{
 			var dataArray = new byte[GetBufferSize(format, pixelWidth, pixelHeight)];
 			inputStream.Read(dataArray, 0, dataArray.Length);
@@ -150,14 +150,14 @@ namespace BCnEncoder.Decoder
 		}
 
 		/// <summary>
-		/// DecodeInternal raw encoded image data.
+		/// Decode raw encoded image data.
 		/// </summary>
 		/// <param name="input">The array containing the encoded data.</param>
 		/// <param name="pixelWidth">The pixelWidth of the image.</param>
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public ColorRgba32[] DecodeRaw(byte[] input, int pixelWidth, int pixelHeight, CompressionFormat format)
+		public ReadOnlyMemory<ColorRgba32> DecodeRaw(byte[] input, int pixelWidth, int pixelHeight, CompressionFormat format)
 		{
 			return DecodeRawInternal(input, pixelWidth, pixelHeight, format, default);
 		}
@@ -167,7 +167,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="inputStream">The stream containing a Ktx or Dds file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public ColorRgba32[] Decode(Stream inputStream)
+		public ReadOnlyMemory<ColorRgba32> Decode(Stream inputStream)
 		{
 			return DecodeInternal(inputStream, false, default)[0];
 		}
@@ -177,7 +177,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="inputStream">The stream containing a Ktx or Dds file.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		public ColorRgba32[][] DecodeAllMipMaps(Stream inputStream)
+		public ReadOnlyMemory<ColorRgba32>[] DecodeAllMipMaps(Stream inputStream)
 		{
 			return DecodeInternal(inputStream, true, default);
 		}
@@ -187,7 +187,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public ColorRgba32[] Decode(KtxFile file)
+		public ReadOnlyMemory<ColorRgba32> Decode(KtxFile file)
 		{
 			return DecodeInternal(file, false, default)[0];
 		}
@@ -197,7 +197,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		public ColorRgba32[][] DecodeAllMipMaps(KtxFile file)
+		public ReadOnlyMemory<ColorRgba32>[] DecodeAllMipMaps(KtxFile file)
 		{
 			return DecodeInternal(file, true, default);
 		}
@@ -207,7 +207,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Dds file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public ColorRgba32[] Decode(DdsFile file)
+		public ReadOnlyMemory<ColorRgba32> Decode(DdsFile file)
 		{
 			return DecodeInternal(file, false, default)[0];
 		}
@@ -217,7 +217,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Dds file.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		public ColorRgba32[][] DecodeAllMipMaps(DdsFile file)
+		public ReadOnlyMemory<ColorRgba32>[] DecodeAllMipMaps(DdsFile file)
 		{
 			return DecodeInternal(file, true, default);
 		}
@@ -231,7 +231,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="allMipMaps">If all mip maps or only the main image should be decoded.</param>
 		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		private ColorRgba32[][] DecodeInternal(Stream stream, bool allMipMaps, CancellationToken token)
+		private ReadOnlyMemory<ColorRgba32>[] DecodeInternal(Stream stream, bool allMipMaps, CancellationToken token)
 		{
 			var format = ImageFile.DetermineImageFormat(stream);
 
@@ -255,9 +255,9 @@ namespace BCnEncoder.Decoder
 		/// <param name="allMipMaps">If all mip maps or only the main image should be decoded.</param>
 		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		private ColorRgba32[][] DecodeInternal(KtxFile file, bool allMipMaps, CancellationToken token)
+		private ReadOnlyMemory<ColorRgba32>[] DecodeInternal(KtxFile file, bool allMipMaps, CancellationToken token)
 		{
-			var colors = new ColorRgba32[file.MipMaps.Count][];
+			var colors = new ReadOnlyMemory<ColorRgba32>[file.MipMaps.Count];
 
 			var context = new OperationContext
 			{
@@ -319,9 +319,9 @@ namespace BCnEncoder.Decoder
 		/// <param name="allMipMaps">If all mip maps or only the main image should be decoded.</param>
 		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		private ColorRgba32[][] DecodeInternal(DdsFile file, bool allMipMaps, CancellationToken token)
+		private ReadOnlyMemory<ColorRgba32>[] DecodeInternal(DdsFile file, bool allMipMaps, CancellationToken token)
 		{
-			var colors = new ColorRgba32[file.header.dwMipMapCount][];
+			var colors = new ReadOnlyMemory<ColorRgba32>[file.header.dwMipMapCount];
 
 			var context = new OperationContext
 			{
@@ -382,7 +382,7 @@ namespace BCnEncoder.Decoder
 		}
 
 		/// <summary>
-		/// DecodeInternal raw encoded image asynchronously.
+		/// Decode raw encoded image asynchronously.
 		/// </summary>
 		/// <param name="input">The <see cref="ReadOnlyMemory{T}"/> containing the encoded data.</param>
 		/// <param name="pixelWidth">The width of the image.</param>
@@ -390,7 +390,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="format">The Format the encoded data is in.</param>
 		/// <param name="token">The cancellation token for this operation. May be default, if the operation is not asynchronous.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		private ColorRgba32[] DecodeRawInternal(ReadOnlyMemory<byte> input, int pixelWidth, int pixelHeight, CompressionFormat format, CancellationToken token)
+		private ReadOnlyMemory<ColorRgba32> DecodeRawInternal(ReadOnlyMemory<byte> input, int pixelWidth, int pixelHeight, CompressionFormat format, CancellationToken token)
 		{
 			if (input.Length % GetBlockSize(format) != 0)
 			{

--- a/BCnEnc.Net/Decoder/BcDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcDecoder.cs
@@ -43,7 +43,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<Memory<ColorRgba32>> DecodeRawAsync(Stream inputStream, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
+		public Task<ColorRgba32[]> DecodeRawAsync(Stream inputStream, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
 		{
 			var dataArray = new byte[GetBufferSize(format, pixelWidth, pixelHeight)];
 			inputStream.Read(dataArray, 0, dataArray.Length);
@@ -60,7 +60,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<Memory<ColorRgba32>> DecodeRawAsync(ReadOnlyMemory<byte> input, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
+		public Task<ColorRgba32[]> DecodeRawAsync(ReadOnlyMemory<byte> input, CompressionFormat format, int pixelWidth, int pixelHeight, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeRawInternal(input, pixelWidth, pixelHeight, format, token), token);
 		}
@@ -71,7 +71,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<Memory<ColorRgba32>> DecodeAsync(KtxFile file, CancellationToken token = default)
+		public Task<ColorRgba32[]> DecodeAsync(KtxFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, false, token)[0], token);
 		}
@@ -82,7 +82,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<Memory<ColorRgba32>[]> DecodeAllMipMapsAsync(KtxFile file, CancellationToken token = default)
+		public Task<ColorRgba32[][]> DecodeAllMipMapsAsync(KtxFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, true, token), token);
 		}
@@ -93,7 +93,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Dds file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<Memory<ColorRgba32>> DecodeAsync(DdsFile file, CancellationToken token = default)
+		public Task<ColorRgba32[]> DecodeAsync(DdsFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, false, token)[0], token);
 		}
@@ -104,7 +104,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="file">The loaded Dds file.</param>
 		/// <param name="token">The cancellation token for this asynchronous operation.</param>
 		/// <returns>The awaitable operation to retrieve the decoded Rgba32 image.</returns>
-		public Task<Memory<ColorRgba32>[]> DecodeAllMipMapsAsync(DdsFile file, CancellationToken token = default)
+		public Task<ColorRgba32[][]> DecodeAllMipMapsAsync(DdsFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, true, token), token);
 		}
@@ -112,7 +112,7 @@ namespace BCnEncoder.Decoder
 		/// <summary>
 		/// Decode raw encoded image asynchronously.
 		/// </summary>
-		/// <param name="inputStream">The stream containing the encoded data.</param>
+		/// <param name="inputStream">The stream containing the raw encoded data.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
 		/// <param name="pixelWidth">The pixelWidth of the image.</param>
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
@@ -124,7 +124,7 @@ namespace BCnEncoder.Decoder
 			inputStream.Read(dataArray, 0, dataArray.Length);
 
 			return Task.Run(() => DecodeRawInternal(dataArray, pixelWidth, pixelHeight, format, token)
-				.AsMemory2D(pixelHeight, pixelWidth), token);
+				.AsMemory().AsMemory2D(pixelHeight, pixelWidth), token);
 		}
 
 		/// <summary>
@@ -139,7 +139,7 @@ namespace BCnEncoder.Decoder
 		public Task<Memory2D<ColorRgba32>> DecodeRaw2DAsync(ReadOnlyMemory<byte> input, int pixelWidth, int pixelHeight, CompressionFormat format, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeRawInternal(input, pixelWidth, pixelHeight, format, token)
-				.AsMemory2D(pixelHeight, pixelWidth), token);
+				.AsMemory().AsMemory2D(pixelHeight, pixelWidth), token);
 		}
 
 		/// <summary>
@@ -173,7 +173,7 @@ namespace BCnEncoder.Decoder
 		public Task<Memory2D<ColorRgba32>> Decode2DAsync(KtxFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, false, token)[0]
-				.AsMemory2D((int)file.header.PixelHeight, (int)file.header.PixelWidth), token);
+				.AsMemory().AsMemory2D((int)file.header.PixelHeight, (int)file.header.PixelWidth), token);
 		}
 
 		/// <summary>
@@ -191,7 +191,7 @@ namespace BCnEncoder.Decoder
 				for (var i = 0; i < decoded.Length; i++)
 				{
 					var mip = file.MipMaps[i];
-					mem2Ds[i] = decoded[i].AsMemory2D((int)mip.Height, (int)mip.Width);
+					mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int)mip.Height, (int)mip.Width);
 				}
 				return mem2Ds;
 			}, token);
@@ -206,7 +206,7 @@ namespace BCnEncoder.Decoder
 		public Task<Memory2D<ColorRgba32>> Decode2DAsync(DdsFile file, CancellationToken token = default)
 		{
 			return Task.Run(() => DecodeInternal(file, false, token)[0]
-				.AsMemory2D((int)file.header.dwHeight, (int)file.header.dwWidth), token);
+				.AsMemory().AsMemory2D((int)file.header.dwHeight, (int)file.header.dwWidth), token);
 		}
 
 		/// <summary>
@@ -224,7 +224,7 @@ namespace BCnEncoder.Decoder
 				for (var i = 0; i < decoded.Length; i++)
 				{
 					var mip = file.Faces[0].MipMaps[i];
-					mem2Ds[i] = decoded[i].AsMemory2D((int)mip.Height, (int)mip.Width);
+					mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int)mip.Height, (int)mip.Width);
 				}
 				return mem2Ds;
 			}, token);
@@ -237,12 +237,12 @@ namespace BCnEncoder.Decoder
 		/// <summary>
 		/// Decode raw encoded image data.
 		/// </summary>
-		/// <param name="inputStream">The stream containing the encoded data.</param>
+		/// <param name="inputStream">The stream containing the raw encoded data.</param>
 		/// <param name="pixelWidth">The pixelWidth of the image.</param>
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public Memory<ColorRgba32> DecodeRaw(Stream inputStream, int pixelWidth, int pixelHeight, CompressionFormat format)
+		public ColorRgba32[] DecodeRaw(Stream inputStream, int pixelWidth, int pixelHeight, CompressionFormat format)
 		{
 			var dataArray = new byte[GetBufferSize(format, pixelWidth, pixelHeight)];
 			inputStream.Read(dataArray, 0, dataArray.Length);
@@ -253,12 +253,12 @@ namespace BCnEncoder.Decoder
 		/// <summary>
 		/// Decode raw encoded image data.
 		/// </summary>
-		/// <param name="input">The array containing the encoded data.</param>
+		/// <param name="input">The byte array containing the raw encoded data.</param>
 		/// <param name="pixelWidth">The pixelWidth of the image.</param>
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public Memory<ColorRgba32> DecodeRaw(byte[] input, int pixelWidth, int pixelHeight, CompressionFormat format)
+		public ColorRgba32[] DecodeRaw(byte[] input, int pixelWidth, int pixelHeight, CompressionFormat format)
 		{
 			return DecodeRawInternal(input, pixelWidth, pixelHeight, format, default);
 		}
@@ -268,7 +268,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public Memory<ColorRgba32> Decode(KtxFile file)
+		public ColorRgba32[] Decode(KtxFile file)
 		{
 			return DecodeInternal(file, false, default)[0];
 		}
@@ -278,7 +278,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		public Memory<ColorRgba32>[] DecodeAllMipMaps(KtxFile file)
+		public ColorRgba32[][] DecodeAllMipMaps(KtxFile file)
 		{
 			return DecodeInternal(file, true, default);
 		}
@@ -288,7 +288,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Dds file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		public Memory<ColorRgba32> Decode(DdsFile file)
+		public ColorRgba32[] Decode(DdsFile file)
 		{
 			return DecodeInternal(file, false, default)[0];
 		}
@@ -298,7 +298,7 @@ namespace BCnEncoder.Decoder
 		/// </summary>
 		/// <param name="file">The loaded Dds file.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		public Memory<ColorRgba32>[] DecodeAllMipMaps(DdsFile file)
+		public ColorRgba32[][] DecodeAllMipMaps(DdsFile file)
 		{
 			return DecodeInternal(file, true, default);
 		}
@@ -317,13 +317,13 @@ namespace BCnEncoder.Decoder
 			inputStream.Read(dataArray, 0, dataArray.Length);
 
 			var decoded = DecodeRaw(dataArray, pixelWidth, pixelHeight, format);
-			return decoded.AsMemory2D(pixelHeight, pixelWidth);
+			return decoded.AsMemory().AsMemory2D(pixelHeight, pixelWidth);
 		}
 
 		/// <summary>
 		/// Decode raw encoded image data.
 		/// </summary>
-		/// <param name="input">The array containing the encoded data.</param>
+		/// <param name="input">The byte array containing the raw encoded data.</param>
 		/// <param name="pixelWidth">The pixelWidth of the image.</param>
 		/// <param name="pixelHeight">The pixelHeight of the image.</param>
 		/// <param name="format">The Format the encoded data is in.</param>
@@ -331,11 +331,11 @@ namespace BCnEncoder.Decoder
 		public Memory2D<ColorRgba32> DecodeRaw2D(byte[] input, int pixelWidth, int pixelHeight, CompressionFormat format)
 		{
 			var decoded = DecodeRawInternal(input, pixelWidth, pixelHeight, format, default);
-			return decoded.AsMemory2D(pixelHeight, pixelWidth);
+			return decoded.AsMemory().AsMemory2D(pixelHeight, pixelWidth);
 		}
 
 		/// <summary>
-		/// Read a Ktx or a Dds file from a stream and decode it.
+		/// Read a Ktx or a Dds file from a stream and decode the largest mipmap from it.
 		/// </summary>
 		/// <param name="inputStream">The stream containing a Ktx or Dds file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
@@ -355,13 +355,13 @@ namespace BCnEncoder.Decoder
 		}
 
 		/// <summary>
-		/// Read a Ktx file and decode it.
+		/// Read a Ktx file and decode the largest mipmap from it.
 		/// </summary>
 		/// <param name="file">The loaded Ktx file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
 		public Memory2D<ColorRgba32> Decode2D(KtxFile file)
 		{
-			return DecodeInternal(file, false, default)[0].AsMemory2D((int)file.header.PixelHeight, (int)file.header.PixelWidth);
+			return DecodeInternal(file, false, default)[0].AsMemory().AsMemory2D((int)file.header.PixelHeight, (int)file.header.PixelWidth);
 		}
 
 		/// <summary>
@@ -376,19 +376,19 @@ namespace BCnEncoder.Decoder
 			for (var i = 0; i < decoded.Length; i++)
 			{
 				var mip = file.MipMaps[i];
-				mem2Ds[i] = decoded[i].AsMemory2D((int)mip.Height, (int)mip.Width);
+				mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int)mip.Height, (int)mip.Width);
 			}
 			return mem2Ds;
 		}
 
 		/// <summary>
-		/// Read a Dds file and decode it.
+		/// Read a Dds file and decode the largest mipmap from it.
 		/// </summary>
 		/// <param name="file">The loaded Dds file.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
 		public Memory2D<ColorRgba32> Decode2D(DdsFile file)
 		{
-			return DecodeInternal(file, false, default)[0].AsMemory2D((int)file.header.dwHeight, (int)file.header.dwWidth);
+			return DecodeInternal(file, false, default)[0].AsMemory().AsMemory2D((int)file.header.dwHeight, (int)file.header.dwWidth);
 		}
 
 		/// <summary>
@@ -403,9 +403,75 @@ namespace BCnEncoder.Decoder
 			for (var i = 0; i < decoded.Length; i++)
 			{
 				var mip = file.Faces[0].MipMaps[i];
-				mem2Ds[i] = decoded[i].AsMemory2D((int)mip.Height, (int)mip.Width);
+				mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int)mip.Height, (int)mip.Width);
 			}
 			return mem2Ds;
+		}
+
+		/// <summary>
+		/// Decode a single block from raw bytes and return it as a <see cref="Memory2D{T}"/>.
+		/// Input Span size needs to equal the block size.
+		/// To get the block size of the compression format used, see <see cref="GetBlockSize(BCnEncoder.Shared.CompressionFormat)"/>.
+		/// </summary>
+		/// <param name="blockData">The encoded block in bytes.</param>
+		/// <param name="format">The compression format used.</param>
+		/// <returns>The decoded 4x4 block.</returns>
+		public Memory2D<ColorRgba32> DecodeBlock(ReadOnlySpan<byte> blockData, CompressionFormat format)
+		{
+			var output = new ColorRgba32[4, 4];
+			DecodeBlockInternal(blockData, format, output);
+			return output;
+		}
+
+		/// <summary>
+		/// Decode a single block from raw bytes and write it to the given output span.
+		/// Output span size must be exactly 4x4 and input Span size needs to equal the block size.
+		/// To get the block size of the compression format used, see <see cref="GetBlockSize(BCnEncoder.Shared.CompressionFormat)"/>.
+		/// </summary>
+		/// <param name="blockData">The encoded block in bytes.</param>
+		/// <param name="format">The compression format used.</param>
+		/// <param name="outputSpan">The destination span of the decoded data.</param>
+		public void DecodeBlock(ReadOnlySpan<byte> blockData, CompressionFormat format, Span2D<ColorRgba32> outputSpan)
+		{
+			if (outputSpan.Width != 4 || outputSpan.Height != 4)
+			{
+				throw new ArgumentException($"Single block decoding needs an output span of exactly 4x4");
+			}
+			DecodeBlockInternal(blockData, format, outputSpan);
+		}
+
+		/// <summary>
+		/// Decode a single block from a stream and write it to the given output span.
+		/// Output span size must be exactly 4x4.
+		/// </summary>
+		/// <param name="inputStream">The stream to read encoded blocks from.</param>
+		/// <param name="format">The compression format used.</param>
+		/// <param name="outputSpan">The destination span of the decoded data.</param>
+		/// <returns>The number of bytes read from the stream. Zero (0) if reached the end of stream.</returns>
+		public int DecodeBlock(Stream inputStream, CompressionFormat format, Span2D<ColorRgba32> outputSpan)
+		{
+			if (outputSpan.Width != 4 || outputSpan.Height != 4)
+			{
+				throw new ArgumentException($"Single block decoding needs an output span of exactly 4x4");
+			}
+
+			Span<byte> input = stackalloc byte[16];
+			input = input.Slice(0, GetBlockSize(format));
+			
+			var bytesRead = inputStream.Read(input);
+
+			if (bytesRead == 0)
+			{
+				return 0; //End of stream
+			}
+			
+			if (bytesRead != input.Length)
+			{
+				throw new Exception("Input stream does not have enough data available for a full block.");
+			}
+
+			DecodeBlockInternal(input, format, outputSpan);
+			return bytesRead;
 		}
 
 		#endregion
@@ -431,7 +497,7 @@ namespace BCnEncoder.Decoder
 					for (var i = 0; i < decoded.Length; i++)
 					{
 						var mip = file.Faces[0].MipMaps[i];
-						mem2Ds[i] = decoded[i].AsMemory2D((int) mip.Height, (int) mip.Width);
+						mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int) mip.Height, (int) mip.Width);
 					}
 
 					return mem2Ds;
@@ -445,7 +511,7 @@ namespace BCnEncoder.Decoder
 					for (var i = 0; i < decoded.Length; i++)
 					{
 						var mip = file.MipMaps[i];
-						mem2Ds[i] = decoded[i].AsMemory2D((int) mip.Height, (int) mip.Width);
+						mem2Ds[i] = decoded[i].AsMemory().AsMemory2D((int) mip.Height, (int) mip.Width);
 					}
 
 					return mem2Ds;
@@ -463,9 +529,10 @@ namespace BCnEncoder.Decoder
 		/// <param name="allMipMaps">If all mip maps or only the main image should be decoded.</param>
 		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		private Memory<ColorRgba32>[] DecodeInternal(KtxFile file, bool allMipMaps, CancellationToken token)
+		private ColorRgba32[][] DecodeInternal(KtxFile file, bool allMipMaps, CancellationToken token)
 		{
-			var colors = new Memory<ColorRgba32>[allMipMaps ? file.MipMaps.Count : 1];
+			var mipMaps = allMipMaps ? file.MipMaps.Count : 1;
+			var colors = new ColorRgba32[mipMaps][];
 
 			var context = new OperationContext
 			{
@@ -483,8 +550,7 @@ namespace BCnEncoder.Decoder
 			if (IsSupportedRawFormat(file.header.GlInternalFormat))
 			{
 				var decoder = GetRawDecoder(file.header.GlInternalFormat);
-
-				var mipMaps = allMipMaps ? file.MipMaps.Count : 1;
+				
 				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.MipMaps[mip].Faces[0].Data;
@@ -501,8 +567,7 @@ namespace BCnEncoder.Decoder
 				{
 					throw new NotSupportedException($"This Format is not supported: {file.header.GlInternalFormat}");
 				}
-
-				var mipMaps = allMipMaps ? file.MipMaps.Count : 1;
+				
 				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.MipMaps[mip].Faces[0].Data;
@@ -527,9 +592,10 @@ namespace BCnEncoder.Decoder
 		/// <param name="allMipMaps">If all mip maps or only the main image should be decoded.</param>
 		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
 		/// <returns>An array of decoded Rgba32 images.</returns>
-		private Memory<ColorRgba32>[] DecodeInternal(DdsFile file, bool allMipMaps, CancellationToken token)
+		private ColorRgba32[][] DecodeInternal(DdsFile file, bool allMipMaps, CancellationToken token)
 		{
-			var colors = new Memory<ColorRgba32>[file.header.dwMipMapCount];
+			var mipMaps = allMipMaps ? file.header.dwMipMapCount : 1;
+			var colors = new ColorRgba32[mipMaps][];
 
 			var context = new OperationContext
 			{
@@ -547,8 +613,7 @@ namespace BCnEncoder.Decoder
 			if (IsSupportedRawFormat(file))
 			{
 				var decoder = GetRawDecoder(file);
-
-				var mipMaps = allMipMaps ? file.header.dwMipMapCount : 1;
+				
 				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.Faces[0].MipMaps[mip].Data;
@@ -569,8 +634,8 @@ namespace BCnEncoder.Decoder
 				{
 					throw new NotSupportedException($"This Format is not supported: {format}");
 				}
-
-				for (var mip = 0; mip < file.header.dwMipMapCount; mip++)
+				
+				for (var mip = 0; mip < mipMaps; mip++)
 				{
 					var data = file.Faces[0].MipMaps[mip].Data;
 					var pixelWidth = file.Faces[0].MipMaps[mip].Width;
@@ -598,7 +663,7 @@ namespace BCnEncoder.Decoder
 		/// <param name="format">The Format the encoded data is in.</param>
 		/// <param name="token">The cancellation token for this operation. May be default, if the operation is not asynchronous.</param>
 		/// <returns>The decoded Rgba32 image.</returns>
-		private Memory<ColorRgba32> DecodeRawInternal(ReadOnlyMemory<byte> input, int pixelWidth, int pixelHeight, CompressionFormat format, CancellationToken token)
+		private ColorRgba32[] DecodeRawInternal(ReadOnlyMemory<byte> input, int pixelWidth, int pixelHeight, CompressionFormat format, CancellationToken token)
 		{
 			if (input.Length % GetBlockSize(format) != 0)
 			{
@@ -623,6 +688,12 @@ namespace BCnEncoder.Decoder
 			{
 				// DecodeInternal as compressed data
 				var decoder = GetDecoder(format);
+
+				if (decoder == null)
+				{
+					throw new NotSupportedException($"This Format is not supported: {format}");
+				}
+
 				var blocks = decoder.Decode(input, context);
 
 				return ImageToBlocks.ColorsFromRawBlocks(blocks, pixelWidth, pixelHeight); ;
@@ -632,6 +703,27 @@ namespace BCnEncoder.Decoder
 			var rawDecoder = GetRawDecoder(format);
 
 			return rawDecoder.Decode(input, context);
+		}
+
+		private void DecodeBlockInternal(ReadOnlySpan<byte> blockData, CompressionFormat format, Span2D<ColorRgba32> outputSpan)
+		{
+			var decoder = GetDecoder(format);
+			if (decoder == null)
+			{
+				throw new NotSupportedException($"This Format is not supported: {format}");
+			}
+			if (blockData.Length != GetBlockSize(format))
+			{
+				throw new ArgumentException("The size of the input buffer does not align with the compression format.");
+			}
+
+			var rawBlock = decoder.DecodeBlock(blockData);
+			var pixels = rawBlock.AsSpan;
+
+			pixels.Slice(0, 4).CopyTo(outputSpan.GetRowSpan(0));
+			pixels.Slice(4, 4).CopyTo(outputSpan.GetRowSpan(1));
+			pixels.Slice(8, 4).CopyTo(outputSpan.GetRowSpan(2));
+			pixels.Slice(12, 4).CopyTo(outputSpan.GetRowSpan(3));
 		}
 
 		#region Support
@@ -759,6 +851,29 @@ namespace BCnEncoder.Decoder
 
 		#region Get block size
 
+		/// <summary>
+		/// Gets the number of total blocks in an image with the given pixel width and height.
+		/// </summary>
+		/// <param name="pixelWidth">The pixel width of the image</param>
+		/// <param name="pixelHeight">The pixel height of the image</param>
+		/// <returns>The total number of blocks.</returns>
+		public int GetBlockCount(int pixelWidth, int pixelHeight)
+		{
+			return ImageToBlocks.CalculateNumOfBlocks(pixelWidth, pixelHeight);
+		}
+
+		/// <summary>
+		/// Gets the number of blocks in an image with the given pixel width and height.
+		/// </summary>
+		/// <param name="pixelWidth">The pixel width of the image</param>
+		/// <param name="pixelHeight">The pixel height of the image</param>
+		/// <param name="blocksWidth">The amount of blocks in the x-axis</param>
+		/// <param name="blocksHeight">The amount of blocks in the y-axis</param>
+		public void GetBlockCount(int pixelWidth, int pixelHeight, out int blocksWidth, out int blocksHeight)
+		{
+			ImageToBlocks.CalculateNumOfBlocks(pixelWidth, pixelHeight, out blocksWidth, out blocksHeight);
+		}
+
 		private int GetBlockSize(GlInternalFormat format)
 		{
 			return GetBlockSize(GetCompressionFormat(format));
@@ -769,7 +884,12 @@ namespace BCnEncoder.Decoder
 			return GetBlockSize(GetCompressionFormat(file));
 		}
 
-		private int GetBlockSize(CompressionFormat format)
+		/// <summary>
+		/// Get the size of blocks for the given compression format in bytes.
+		/// </summary>
+		/// <param name="format">The compression format used.</param>
+		/// <returns>The size of a single block in bytes.</returns>
+		public int GetBlockSize(CompressionFormat format)
 		{
 			switch (format)
 			{
@@ -839,7 +959,7 @@ namespace BCnEncoder.Decoder
 				case GlInternalFormat.GlRgba8:
 					return CompressionFormat.Rgba;
 
-				// HINT: Bgra is only an extension by apple to the ktx format
+				// HINT: Bgra is not supported by default. The format enum is added by an extension by Apple.
 				case GlInternalFormat.GlBgra8Extension:
 					return CompressionFormat.Bgra;
 
@@ -905,7 +1025,7 @@ namespace BCnEncoder.Decoder
 				case DxgiFormat.DxgiFormatBc1Unorm:
 				case DxgiFormat.DxgiFormatBc1UnormSrgb:
 				case DxgiFormat.DxgiFormatBc1Typeless:
-					if (file.header.ddsPixelFormat.dwFlags.HasFlag(PixelFormatFlags.DdpfAlphapixels))
+					if (file.header.ddsPixelFormat.dwFlags.HasFlag(PixelFormatFlags.DdpfAlphaPixels))
 						return CompressionFormat.Bc1WithAlpha;
 
 					if (InputOptions.DdsBc1ExpectAlpha)
@@ -938,13 +1058,13 @@ namespace BCnEncoder.Decoder
 				case DxgiFormat.DxgiFormatBc7Typeless:
 					return CompressionFormat.Bc7;
 
-				case DxgiFormat.DxgiFormatAtc:
+				case DxgiFormat.DxgiFormatAtcExt:
 					return CompressionFormat.Atc;
 
-				case DxgiFormat.DxgiFormatAtcExplicitAlpha:
+				case DxgiFormat.DxgiFormatAtcExplicitAlphaExt:
 					return CompressionFormat.AtcExplicitAlpha;
 
-				case DxgiFormat.DxgiFormatAtcInterpolatedAlpha:
+				case DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt:
 					return CompressionFormat.AtcInterpolatedAlpha;
 
 				default:

--- a/BCnEnc.Net/Decoder/Options/DecoderOutputOptions.cs
+++ b/BCnEnc.Net/Decoder/Options/DecoderOutputOptions.cs
@@ -9,24 +9,25 @@ namespace BCnEncoder.Decoder.Options
 	public class DecoderOutputOptions
 	{
 		/// <summary>
-		/// If true, when decoding from a Format that only includes a red channel,
-		/// output pixels will have all colors set to the same value (greyscale). Default is true.
+		/// If true, when decoding from R8 raw format,
+		/// output pixels will have all colors set to the same value (greyscale).
+		/// Default is true. (Does not apply to BC4 format.)
 		/// </summary>
 		public bool RedAsLuminance { get; set; } = true;
 
 		/// <summary>
 		/// The color channel to populate with the values of a BC4 block.
 		/// </summary>
-		public Bc4Component Bc4Component { get; } = Bc4Component.R;
+		public Bc4Component Bc4Component { get; set; } = Bc4Component.R;
 
 		/// <summary>
 		/// The color channel to populate with the values of the first BC5 block.
 		/// </summary>
-		public Bc4Component Bc5Component1 { get; } = Bc4Component.R;
+		public Bc4Component Bc5Component1 { get; set; } = Bc4Component.R;
 
 		/// <summary>
 		/// The color channel to populate with the values of the second BC5 block.
 		/// </summary>
-		public Bc4Component Bc5Component2 { get; } = Bc4Component.G;
+		public Bc4Component Bc5Component2 { get; set; } = Bc4Component.G;
 	}
 }

--- a/BCnEnc.Net/Decoder/Options/DecoderOutputOptions.cs
+++ b/BCnEnc.Net/Decoder/Options/DecoderOutputOptions.cs
@@ -1,14 +1,32 @@
-﻿namespace BCnEncoder.Decoder.Options
+using BCnEncoder.Encoder;
+using BCnEncoder.Shared;
+
+namespace BCnEncoder.Decoder.Options
 {
-    /// <summary>
-    /// A class for the decoder output options.
-    /// </summary>
+	/// <summary>
+	/// A class for the decoder output options.
+	/// </summary>
 	public class DecoderOutputOptions
-    {
-        /// <summary>
-        /// If true, when decoding from a Format that only includes a red channel,
-        /// output pixels will have all colors set to the same value (greyscale). Default is true.
-        /// </summary>
-        public bool RedAsLuminance { get; set; } = true;
-    }
+	{
+		/// <summary>
+		/// If true, when decoding from a Format that only includes a red channel,
+		/// output pixels will have all colors set to the same value (greyscale). Default is true.
+		/// </summary>
+		public bool RedAsLuminance { get; set; } = true;
+
+		/// <summary>
+		/// The color channel to populate with the values of a BC4 block.
+		/// </summary>
+		public Bc4Component Bc4Component { get; } = Bc4Component.R;
+
+		/// <summary>
+		/// The color channel to populate with the values of the first BC5 block.
+		/// </summary>
+		public Bc4Component Bc5Component1 { get; } = Bc4Component.R;
+
+		/// <summary>
+		/// The color channel to populate with the values of the second BC5 block.
+		/// </summary>
+		public Bc4Component Bc5Component2 { get; } = Bc4Component.G;
+	}
 }

--- a/BCnEnc.Net/Decoder/RawDecoder.cs
+++ b/BCnEnc.Net/Decoder/RawDecoder.cs
@@ -1,4 +1,3 @@
-using SixLabors.ImageSharp.PixelFormats;
 using System;
 using BCnEncoder.Shared;
 
@@ -6,7 +5,7 @@ namespace BCnEncoder.Decoder
 {
 	internal interface IRawDecoder
 	{
-		Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context);
+		ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context);
 	}
 
 	/// <summary>
@@ -29,13 +28,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -46,18 +43,18 @@ namespace BCnEncoder.Decoder
 
 				if (redAsLuminance)
 				{
-					output[i].R = span[i];
-					output[i].G = span[i];
-					output[i].B = span[i];
+					output[i].r = span[i];
+					output[i].g = span[i];
+					output[i].b = span[i];
 				}
 				else
 				{
-					output[i].R = span[i];
-					output[i].G = 0;
-					output[i].B = 0;
+					output[i].r = span[i];
+					output[i].g = 0;
+					output[i].b = 0;
 				}
 
-				output[i].A = 255;
+				output[i].a = 255;
 			}
 
 			return output;
@@ -73,13 +70,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 2];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -88,10 +83,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].R = span[i * 2];
-				output[i].G = span[i * 2 + 1];
-				output[i].B = 0;
-				output[i].A = 255;
+				output[i].r = span[i * 2];
+				output[i].g = span[i * 2 + 1];
+				output[i].b = 0;
+				output[i].a = 255;
 			}
 
 			return output;
@@ -107,13 +102,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 3];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -122,10 +115,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].R = span[i * 3];
-				output[i].G = span[i * 3 + 1];
-				output[i].B = span[i * 3 + 2];
-				output[i].A = 255;
+				output[i].r = span[i * 3];
+				output[i].g = span[i * 3 + 1];
+				output[i].b = span[i * 3 + 2];
+				output[i].a = 255;
 			}
 
 			return output;
@@ -141,13 +134,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 4];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -156,10 +147,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].R = span[i * 4];
-				output[i].G = span[i * 4 + 1];
-				output[i].B = span[i * 4 + 2];
-				output[i].A = span[i * 4 + 3];
+				output[i].r = span[i * 4];
+				output[i].g = span[i * 4 + 1];
+				output[i].b = span[i * 4 + 2];
+				output[i].a = span[i * 4 + 3];
 			}
 
 			return output;
@@ -175,13 +166,11 @@ namespace BCnEncoder.Decoder
 		/// Decode the data to color components.
 		/// </summary>
 		/// <param name="data">The data to decode.</param>
-		/// <param name="pixelWidth">The width of the image in pixels.</param>
-		/// <param name="pixelHeight">The height of the image in pixels.</param>
 		/// <param name="context">The context of the current operation.</param>
 		/// <returns>The decoded color components.</returns>
-		public Rgba32[] Decode(ReadOnlyMemory<byte> data, int pixelWidth, int pixelHeight, OperationContext context)
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
 		{
-			var output = new Rgba32[pixelWidth * pixelHeight];
+			var output = new ColorRgba32[data.Length / 4];
 
 			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
 
@@ -190,10 +179,10 @@ namespace BCnEncoder.Decoder
 			{
 				context.CancellationToken.ThrowIfCancellationRequested();
 
-				output[i].B = span[i * 4];
-				output[i].G = span[i * 4 + 1];
-				output[i].R = span[i * 4 + 2];
-				output[i].A = span[i * 4 + 3];
+				output[i].b = span[i * 4];
+				output[i].g = span[i * 4 + 1];
+				output[i].r = span[i * 4 + 2];
+				output[i].a = span[i * 4 + 3];
 			}
 
 			return output;

--- a/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
@@ -1,4 +1,5 @@
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
@@ -69,7 +69,7 @@ namespace BCnEncoder.Encoder
 			var bc2AlphaBlock = new Bc2AlphaBlock();
 			for (var i = 0; i < 16; i++)
 			{
-				bc2AlphaBlock.SetAlpha(i, block[i].A);
+				bc2AlphaBlock.SetAlpha(i, block[i].a);
 			}
 
 			return new AtcExplicitAlphaBlock

--- a/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/AtcBlockEncoder.cs
@@ -48,7 +48,7 @@ namespace BCnEncoder.Encoder
 
 		public override DxgiFormat GetDxgiFormat()
 		{
-			return DxgiFormat.DxgiFormatAtc;
+			return DxgiFormat.DxgiFormatAtcExt;
 		}
 	}
 
@@ -91,7 +91,7 @@ namespace BCnEncoder.Encoder
 
 		public override DxgiFormat GetDxgiFormat()
 		{
-			return DxgiFormat.DxgiFormatAtcExplicitAlpha;
+			return DxgiFormat.DxgiFormatAtcExplicitAlphaExt;
 		}
 	}
 
@@ -130,7 +130,7 @@ namespace BCnEncoder.Encoder
 
 		public override DxgiFormat GetDxgiFormat()
 		{
-			return DxgiFormat.DxgiFormatAtcInterpolatedAlpha;
+			return DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt;
 		}
 	}
 }

--- a/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -49,9 +50,23 @@ namespace BCnEncoder.Encoder
 			return outputData;
 		}
 
+		public void EncodeBlock(RawBlock4X4Rgba32 block, CompressionQuality quality, Span<byte> output)
+		{
+			if (output.Length != Unsafe.SizeOf<T>())
+			{
+				throw new Exception("Cannot encode block! Output buffer is not the correct size.");
+			}
+			T encoded = EncodeBlock(block, quality);
+			MemoryMarshal.Cast<byte, T>(output)[0] = encoded;
+		}
+
 		public abstract GlInternalFormat GetInternalFormat();
 		public abstract GlFormat GetBaseInternalFormat();
 		public abstract DxgiFormat GetDxgiFormat();
+		public int GetBlockSize()
+		{
+			return Unsafe.SizeOf<T>();
+		}
 
 		public abstract T EncodeBlock(RawBlock4X4Rgba32 block, CompressionQuality quality);
 	}

--- a/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
@@ -56,7 +56,7 @@ namespace BCnEncoder.Encoder
 			{
 				throw new Exception("Cannot encode block! Output buffer is not the correct size.");
 			}
-			T encoded = EncodeBlock(block, quality);
+			var encoded = EncodeBlock(block, quality);
 			MemoryMarshal.Cast<byte, T>(output)[0] = encoded;
 		}
 

--- a/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/BaseBcBlockEncoder.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc1BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc1BlockEncoder.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc2BlockEncoder.cs
@@ -62,7 +62,7 @@ namespace BCnEncoder.Encoder
 			for (var i = 0; i < 16; i++)
 			{
 				var color = pixels[i];
-				output.SetAlpha(i, color.A);
+				output.SetAlpha(i, color.a);
 				output[i] = ColorChooser.ChooseClosestColor4(colors, color, rWeight, gWeight, bWeight, out var e);
 				error += e;
 			}

--- a/BCnEnc.Net/Encoder/Bc3BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc3BlockEncoder.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
@@ -5,29 +5,20 @@ using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {
-	internal enum Bc4Component
-	{
-		R,
-		G,
-		B,
-		A,
-		Luminance
-	}
-
 	internal class Bc4BlockEncoder : BaseBcBlockEncoder<Bc4Block>
 	{
 		private readonly Bc4ComponentBlockEncoder bc4Encoder;
 
-		public Bc4BlockEncoder(bool luminanceAsRed)
+		public Bc4BlockEncoder(Bc4Component component)
 		{
-			bc4Encoder = new Bc4ComponentBlockEncoder(luminanceAsRed ? Bc4Component.Luminance : Bc4Component.R);
+			bc4Encoder = new Bc4ComponentBlockEncoder(component);
 		}
 
 		public override Bc4Block EncodeBlock(RawBlock4X4Rgba32 block, CompressionQuality quality)
 		{
 			var output = new Bc4Block
 			{
-				redBlock = bc4Encoder.EncodeBlock(block, quality)
+				componentBlock = bc4Encoder.EncodeBlock(block, quality)
 			};
 
 			return output;
@@ -66,28 +57,7 @@ namespace BCnEncoder.Encoder
 			var colors = new byte[pixels.Length];
 
 			for (var i = 0; i < pixels.Length; i++)
-				switch (component)
-				{
-					case Bc4Component.R:
-						colors[i] = pixels[i].r;
-						break;
-
-					case Bc4Component.G:
-						colors[i] = pixels[i].g;
-						break;
-
-					case Bc4Component.B:
-						colors[i] = pixels[i].b;
-						break;
-
-					case Bc4Component.A:
-						colors[i] = pixels[i].a;
-						break;
-
-					case Bc4Component.Luminance:
-						colors[i] = (byte)(new ColorYCbCr(pixels[i]).y * 255);
-						break;
-				}
+				colors[i] = ComponentHelper.ColorToComponent(pixels[i], component);
 
 			switch (quality)
 			{

--- a/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc4BlockEncoder.cs
@@ -69,19 +69,19 @@ namespace BCnEncoder.Encoder
 				switch (component)
 				{
 					case Bc4Component.R:
-						colors[i] = pixels[i].R;
+						colors[i] = pixels[i].r;
 						break;
 
 					case Bc4Component.G:
-						colors[i] = pixels[i].G;
+						colors[i] = pixels[i].g;
 						break;
 
 					case Bc4Component.B:
-						colors[i] = pixels[i].B;
+						colors[i] = pixels[i].b;
 						break;
 
 					case Bc4Component.A:
-						colors[i] = pixels[i].A;
+						colors[i] = pixels[i].a;
 						break;
 
 					case Bc4Component.Luminance:

--- a/BCnEnc.Net/Encoder/Bc5BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc5BlockEncoder.cs
@@ -8,10 +8,10 @@ namespace BCnEncoder.Encoder
 		private readonly Bc4ComponentBlockEncoder redBlockEncoder;
 		private readonly Bc4ComponentBlockEncoder greenBlockEncoder;
 
-		public Bc5BlockEncoder()
+		public Bc5BlockEncoder(Bc4Component component1, Bc4Component component2)
 		{
-			redBlockEncoder = new Bc4ComponentBlockEncoder(Bc4Component.R);
-			greenBlockEncoder = new Bc4ComponentBlockEncoder(Bc4Component.G);
+			redBlockEncoder = new Bc4ComponentBlockEncoder(component1);
+			greenBlockEncoder = new Bc4ComponentBlockEncoder(component2);
 		}
 
 		public override Bc5Block EncodeBlock(RawBlock4X4Rgba32 block, CompressionQuality quality)

--- a/BCnEnc.Net/Encoder/Bc5BlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/Bc5BlockEncoder.cs
@@ -1,4 +1,5 @@
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
+++ b/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder.Bc7
 {

--- a/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
+++ b/BCnEnc.Net/Encoder/Bc7/Bc7Encoder.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
 

--- a/BCnEnc.Net/Encoder/Bc7/Bc7EncodingHelpers.cs
+++ b/BCnEnc.Net/Encoder/Bc7/Bc7EncodingHelpers.cs
@@ -1,8 +1,7 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using BCnEncoder.Shared;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder.Bc7
 {
@@ -636,7 +635,7 @@ namespace BCnEncoder.Encoder.Bc7
 				}
 			}
 
-			Span<Rgba32> subsetColors = stackalloc Rgba32[count];
+			Span<ColorRgba32> subsetColors = stackalloc ColorRgba32[count];
 			var next = 0;
 			for (var i = 0; i < 16; i++)
 			{
@@ -827,7 +826,7 @@ namespace BCnEncoder.Encoder.Bc7
 					var pixelColor = new ColorYCbCr(pixels[i]);
 
 					FindClosestColorIndex(pixelColor, colors, out var ce);
-					FindClosestAlphaIndex(pixels[i].A, alphas, out var ae);
+					FindClosestAlphaIndex(pixels[i].a, alphas, out var ae);
 
 					error += ce + ae;
 				}
@@ -931,10 +930,10 @@ namespace BCnEncoder.Encoder.Bc7
 				{
 					var pixelColor = new ColorYCbCr(pixels[i]);
 
-					var index = FindClosestColorIndex(pixelColor, colors, out var e);
+					var index = FindClosestColorIndex(pixelColor, colors, out _);
 					colorIndicesToFill[i] = (byte)index;
 
-					index = FindClosestAlphaIndex(pixels[i].A, alphas, out var _);
+					index = FindClosestAlphaIndex(pixels[i].a, alphas, out _);
 					alphaIndicesToFill[i] = (byte)index;
 				}
 			}
@@ -1101,13 +1100,13 @@ namespace BCnEncoder.Encoder.Bc7
 				switch (rotation)
 				{
 					case 1:
-						output[i] = new Rgba32(c.A, c.G, c.B, c.R);
+						output[i] = new ColorRgba32(c.a, c.g, c.b, c.r);
 						break;
 					case 2:
-						output[i] = new Rgba32(c.R, c.A, c.B, c.G);
+						output[i] = new ColorRgba32(c.r, c.a, c.b, c.g);
 						break;
 					case 3:
-						output[i] = new Rgba32(c.R, c.G, c.A, c.B);
+						output[i] = new ColorRgba32(c.r, c.g, c.a, c.b);
 						break;
 				}
 			}

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -209,6 +209,27 @@ namespace BCnEncoder.Encoder
 			return Task.Run(() => EncodeToRawInternal(input, mipLevel, out _, out _, token), token);
 		}
 
+		public Task EncodeCubeMapToStreamAsync(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
+			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, Stream outputStream, CancellationToken token = default)
+		{
+			return Task.Run(() => EncodeCubeMapToStreamInternal(right, left, top, down, back, front, outputStream, token), token);
+		}
+
+		public Task<KtxFile> EncodeCubeMapToKtxAsync(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
+			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, CancellationToken token = default)
+		{
+			return Task.Run(() => EncodeCubeMapToKtxInternal(right, left, top, down, back, front, token), token);
+		}
+
+		public Task<DdsFile> EncodeCubeMapToDdsAsync(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
+			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, CancellationToken token = default)
+		{
+			return Task.Run(() => EncodeCubeMapToDdsInternal(right, left, top, down, back, front, token), token);
+		}
+
 		#endregion
 
 		#region Sync Api
@@ -332,6 +353,27 @@ namespace BCnEncoder.Encoder
 		public byte[] EncodeToRawBytes(ReadOnlyMemory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight)
 		{
 			return EncodeToRawInternal(input, mipLevel, out mipWidth, out mipHeight, default);
+		}
+
+		public void EncodeCubeMapToStream(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
+			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, Stream outputStream)
+		{
+			EncodeCubeMapToStreamInternal(right, left, top, down, back, front, outputStream, default);
+		}
+
+		public KtxFile EncodeCubeMapToKtx(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
+			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front)
+		{
+			return EncodeCubeMapToKtxInternal(right, left, top, down, back, front, default);
+		}
+
+		public DdsFile EncodeCubeMapToDds(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
+			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front)
+		{
+			return EncodeCubeMapToDdsInternal(right, left, top, down, back, front, default);
 		}
 
 		#endregion

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -8,6 +8,7 @@ using BCnEncoder.Encoder.Bc7;
 using BCnEncoder.Encoder.Options;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
+using Microsoft.Toolkit.HighPerformance.Extensions;
 using Microsoft.Toolkit.HighPerformance.Memory;
 
 namespace BCnEncoder.Encoder
@@ -18,27 +19,27 @@ namespace BCnEncoder.Encoder
 	public enum PixelFormat
 	{
 		/// <summary>
-		/// Specifies the RGBA32 layout.
+		/// 8 bits per channel RGBA.
 		/// </summary>
 		Rgba32,
 
 		/// <summary>
-		/// Specifies the BGRA32 layout.
+		/// 8 bits per channel BGRA.
 		/// </summary>
 		Bgra32,
 
 		/// <summary>
-		/// Specifies the ARGB32 layout.
+		/// 8 bits per channel ARGB.
 		/// </summary>
 		Argb32,
 
 		/// <summary>
-		/// Specifies the RGB24 layout.
+		/// 8 bits per channel RGB.
 		/// </summary>
 		Rgb24,
 
 		/// <summary>
-		/// Specifies the BGR24 layout.
+		/// 8 bits per channel BGR.
 		/// </summary>
 		Bgr24
 	}
@@ -77,13 +78,13 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
-		public Task EncodeToStreamAsync(Memory<byte> input, int width, int height, PixelFormat format, Stream outputStream, CancellationToken token = default)
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
+		public Task EncodeToStreamAsync(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, Stream outputStream, CancellationToken token = default)
 		{
 			return Task.Run(() =>
 			{
@@ -94,10 +95,10 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
-		public Task EncodeToStreamAsync(Memory2D<ColorRgba32> input, Stream outputStream, CancellationToken token = default)
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
+		public Task EncodeToStreamAsync(ReadOnlyMemory2D<ColorRgba32> input, Stream outputStream, CancellationToken token = default)
 		{
 			return Task.Run(() =>
 			{
@@ -108,13 +109,13 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a Ktx file asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
 		/// <returns>The Ktx file containing the encoded image.</returns>
-		public Task<KtxFile> EncodeToKtxAsync(Memory<byte> input, int width, int height, PixelFormat format, CancellationToken token = default)
+		public Task<KtxFile> EncodeToKtxAsync(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToKtxInternal(ByteToColorMemory(input.Span, width, height, format), token), token);
 		}
@@ -122,10 +123,10 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a Ktx file asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
 		/// <returns>The Ktx file containing the encoded image.</returns>
-		public Task<KtxFile> EncodeToKtxAsync(Memory2D<ColorRgba32> input, CancellationToken token = default)
+		public Task<KtxFile> EncodeToKtxAsync(ReadOnlyMemory2D<ColorRgba32> input, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToKtxInternal(input, token), token);
 		}
@@ -133,13 +134,13 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a Dds file asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
 		/// <returns>The Dds file containing the encoded image.</returns>
-		public Task<DdsFile> EncodeToDdsAsync(Memory<byte> input, int width, int height, PixelFormat format, CancellationToken token = default)
+		public Task<DdsFile> EncodeToDdsAsync(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToDdsInternal(ByteToColorMemory(input.Span, width, height, format), token), token);
 		}
@@ -147,10 +148,10 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a Dds file asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
 		/// <returns>The Dds file containing the encoded image.</returns>
-		public Task<DdsFile> EncodeToDdsAsync(Memory2D<ColorRgba32> input, CancellationToken token = default)
+		public Task<DdsFile> EncodeToDdsAsync(ReadOnlyMemory2D<ColorRgba32> input, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToDdsInternal(input, token), token);
 		}
@@ -158,13 +159,13 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a list of byte buffers asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
 		/// <returns>A list of raw encoded mipmap input.</returns>
-		public Task<byte[][]> EncodeToRawBytesAsync(Memory<byte> input, int width, int height, PixelFormat format, CancellationToken token = default)
+		public Task<byte[][]> EncodeToRawBytesAsync(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToRawInternal(ByteToColorMemory(input.Span, width, height, format), token), token);
 		}
@@ -172,10 +173,11 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a list of byte buffers asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
 		/// <returns>A list of raw encoded mipmap input.</returns>
-		public Task<byte[][]> EncodeToRawBytesAsync(Memory2D<ColorRgba32> input, CancellationToken token = default)
+		/// <remarks>To get the width and height of the encoded mip levels, see <see cref="CalculateMipMapSize"/>.</remarks>
+		public Task<byte[][]> EncodeToRawBytesAsync(ReadOnlyMemory2D<ColorRgba32> input, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToRawInternal(input, token), token);
 		}
@@ -183,7 +185,7 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes a single mip level of the input image to a byte buffer asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
@@ -191,7 +193,7 @@ namespace BCnEncoder.Encoder
 		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
 		/// <returns>The raw encoded input.</returns>
 		/// <remarks>To get the width and height of the encoded mip level, see <see cref="CalculateMipMapSize"/>.</remarks>
-		public Task<byte[]> EncodeToRawBytesAsync(Memory<byte> input, int width, int height, PixelFormat format, int mipLevel, CancellationToken token = default)
+		public Task<byte[]> EncodeToRawBytesAsync(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, int mipLevel, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToRawInternal(ByteToColorMemory(input.Span, width, height, format), mipLevel, out _, out _, token), token);
 		}
@@ -199,16 +201,30 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes a single mip level of the input image to a byte buffer asynchronously.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
 		/// <param name="mipLevel">The mipmap to encode.</param>
-		/// <param name="token">The cancellation token for this operation. Can be default, if the operation is not asynchronous.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
 		/// <returns>The raw encoded input.</returns>
 		/// <remarks>To get the width and height of the encoded mip level, see <see cref="CalculateMipMapSize"/>.</remarks>
-		public Task<byte[]> EncodeToRawBytesAsync(Memory2D<ColorRgba32> input, int mipLevel, CancellationToken token = default)
+		public Task<byte[]> EncodeToRawBytesAsync(ReadOnlyMemory2D<ColorRgba32> input, int mipLevel, CancellationToken token = default)
 		{
 			return Task.Run(() => EncodeToRawInternal(input, mipLevel, out _, out _, token), token);
 		}
 
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a stream asynchronously either in ktx or dds format.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <param name="outputStream">The stream to write the encoded image to.</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
+		/// <returns>A <see cref="Task"/>.</returns>
 		public Task EncodeCubeMapToStreamAsync(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
 			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
 			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, Stream outputStream, CancellationToken token = default)
@@ -216,6 +232,19 @@ namespace BCnEncoder.Encoder
 			return Task.Run(() => EncodeCubeMapToStreamInternal(right, left, top, down, back, front, outputStream, token), token);
 		}
 
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a <see cref="KtxFile"/> asynchronously.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
+		/// <returns>A <see cref="Task{KtxFile}"/> of type <see cref="KtxFile"/>.</returns>
 		public Task<KtxFile> EncodeCubeMapToKtxAsync(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
 			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
 			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, CancellationToken token = default)
@@ -223,6 +252,19 @@ namespace BCnEncoder.Encoder
 			return Task.Run(() => EncodeCubeMapToKtxInternal(right, left, top, down, back, front, token), token);
 		}
 
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a <see cref="DdsFile"/> asynchronously.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <param name="token">The cancellation token for this operation. Can be default if cancellation is not needed.</param>
+		/// <returns>A <see cref="Task{DdsFile}"/> of type <see cref="DdsFile"/>.</returns>
 		public Task<DdsFile> EncodeCubeMapToDdsAsync(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
 			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
 			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, CancellationToken token = default)
@@ -237,20 +279,20 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlySpan{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
-		/// <param name="format">The pixel format the given data is in.</param>
+		/// <param name="format">The pixel format the input data is in.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		public void EncodeToStream(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, Stream outputStream)
+		public void EncodeToStream(ReadOnlySpan<byte> input, int width, int height, PixelFormat format, Stream outputStream)
 		{
-			EncodeToStream(ByteToColorMemory(input.Span, width, height, format), outputStream);
+			EncodeToStream(ByteToColorMemory(input, width, height, format), outputStream);
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
 		public void EncodeToStream(ReadOnlyMemory2D<ColorRgba32> input, Stream outputStream)
 		{
@@ -260,21 +302,21 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a Ktx file.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlySpan{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
-		/// <param name="format">The pixel format the given data is in.</param>
-		/// <returns>The Ktx file containing the encoded image.</returns>
-		public KtxFile EncodeToKtx(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format)
+		/// <param name="format">The pixel format the input data is in.</param>
+		/// <returns>The <see cref="KtxFile"/> containing the encoded image.</returns>
+		public KtxFile EncodeToKtx(ReadOnlySpan<byte> input, int width, int height, PixelFormat format)
 		{
-			return EncodeToKtx(ByteToColorMemory(input.Span, width, height, format));
+			return EncodeToKtx(ByteToColorMemory(input, width, height, format));
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a Ktx file.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
-		/// <returns>The Ktx file containing the encoded image.</returns>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
+		/// <returns>The <see cref="KtxFile"/> containing the encoded image.</returns>
 		public KtxFile EncodeToKtx(ReadOnlyMemory2D<ColorRgba32> input)
 		{
 			return EncodeToKtxInternal(input, default);
@@ -283,21 +325,21 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a Dds file.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlySpan{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
-		/// <param name="format">The pixel format the given data is in.</param>
-		/// <returns>The Dds file containing the encoded image.</returns>
-		public DdsFile EncodeToDds(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format)
+		/// <param name="format">The pixel format the input data is in.</param>
+		/// <returns>The <see cref="DdsFile"/> containing the encoded image.</returns>
+		public DdsFile EncodeToDds(ReadOnlySpan<byte> input, int width, int height, PixelFormat format)
 		{
-			return EncodeToDds(ByteToColorMemory(input.Span, width, height, format));
+			return EncodeToDds(ByteToColorMemory(input, width, height, format));
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a Dds file.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
-		/// <returns>The Dds file containing the encoded image.</returns>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
+		/// <returns>The <see cref="DdsFile"/> containing the encoded image.</returns>
 		public DdsFile EncodeToDds(ReadOnlyMemory2D<ColorRgba32> input)
 		{
 			return EncodeToDdsInternal(input, default);
@@ -306,21 +348,23 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a list of byte buffers.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlySpan{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
-		/// <param name="format">The pixel format the given data is in.</param>
-		/// <returns>A list of raw encoded mipmap input.</returns>
-		public byte[][] EncodeToRawBytes(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format)
+		/// <param name="format">The pixel format the input data is in.</param>
+		/// <returns>An array of byte buffers containing all mipmap levels.</returns>
+		/// <remarks>To get the width and height of the encoded mip levels, see <see cref="CalculateMipMapSize"/>.</remarks>
+		public byte[][] EncodeToRawBytes(ReadOnlySpan<byte> input, int width, int height, PixelFormat format)
 		{
-			return EncodeToRawBytes(ByteToColorMemory(input.Span, width, height, format));
+			return EncodeToRawBytes(ByteToColorMemory(input, width, height, format));
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a list of byte buffers.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
-		/// <returns>A list of raw encoded mipmap input.</returns>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
+		/// <returns>An array of byte buffers containing all mipmap levels.</returns>
+		/// <remarks>To get the width and height of the encoded mip levels, see <see cref="CalculateMipMapSize"/>.</remarks>
 		public byte[][] EncodeToRawBytes(ReadOnlyMemory2D<ColorRgba32> input)
 		{
 			return EncodeToRawInternal(input, default);
@@ -329,32 +373,74 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes a single mip level of the input image to a byte buffer.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlySpan{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
-		/// <param name="format">The pixel format the given data is in.</param>
+		/// <param name="format">The pixel format the input data is in.</param>
 		/// <param name="mipLevel">The mipmap to encode.</param>
 		/// <param name="mipWidth">The width of the mipmap.</param>
 		/// <param name="mipHeight">The height of the mipmap.</param>
-		/// <returns>The raw encoded input.</returns>
-		public byte[] EncodeToRawBytes(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, int mipLevel, out int mipWidth, out int mipHeight)
+		/// <returns>A byte buffer containing the encoded data of the requested mip-level.</returns>
+		public byte[] EncodeToRawBytes(ReadOnlySpan<byte> input, int width, int height, PixelFormat format, int mipLevel, out int mipWidth, out int mipHeight)
 		{
-			return EncodeToRawInternal(ByteToColorMemory(input.Span, width, height, format), mipLevel, out mipWidth, out mipHeight, default);
+			return EncodeToRawInternal(ByteToColorMemory(input, width, height, format), mipLevel, out mipWidth, out mipHeight, default);
 		}
 
 		/// <summary>
 		/// Encodes a single mip level of the input image to a byte buffer.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory2D{T}"/>.</param>
 		/// <param name="mipLevel">The mipmap to encode.</param>
 		/// <param name="mipWidth">The width of the mipmap.</param>
 		/// <param name="mipHeight">The height of the mipmap.</param>
-		/// <returns>The raw encoded input.</returns>
+		/// <returns>A byte buffer containing the encoded data of the requested mip-level.</returns>
 		public byte[] EncodeToRawBytes(ReadOnlyMemory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight)
 		{
 			return EncodeToRawInternal(input, mipLevel, out mipWidth, out mipHeight, default);
 		}
 
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a stream either in ktx or dds format.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <param name="width">The width of the faces.</param>
+		/// <param name="height">The height of the faces.</param>
+		/// <param name="format">The pixel format the input data is in.</param>
+		/// <param name="outputStream">The stream to write the encoded image to.</param>
+		public void EncodeCubeMapToStream(ReadOnlySpan<byte> right, ReadOnlySpan<byte> left,
+			ReadOnlySpan<byte> top, ReadOnlySpan<byte> down,
+			ReadOnlySpan<byte> back, ReadOnlySpan<byte> front,
+			int width, int height, PixelFormat format, Stream outputStream)
+		{
+			EncodeCubeMapToStreamInternal(
+				ByteToColorMemory(right, width, height, format),
+				ByteToColorMemory(left, width, height, format),
+				ByteToColorMemory(top, width, height, format),
+				ByteToColorMemory(down, width, height, format),
+				ByteToColorMemory(back, width, height, format),
+				ByteToColorMemory(front, width, height, format),
+				outputStream, default);
+		}
+
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a stream either in ktx or dds format.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <param name="outputStream">The stream to write the encoded image to.</param>
 		public void EncodeCubeMapToStream(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
 			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
 			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, Stream outputStream)
@@ -362,6 +448,47 @@ namespace BCnEncoder.Encoder
 			EncodeCubeMapToStreamInternal(right, left, top, down, back, front, outputStream, default);
 		}
 
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a <see cref="KtxFile"/>.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <param name="width">The width of the faces.</param>
+		/// <param name="height">The height of the faces.</param>
+		/// <param name="format">The pixel format the input data is in.</param>
+		/// <returns>The encoded image as a <see cref="KtxFile"/>.</returns>
+		public KtxFile EncodeCubeMapToKtx(ReadOnlySpan<byte> right, ReadOnlySpan<byte> left,
+			ReadOnlySpan<byte> top, ReadOnlySpan<byte> down,
+			ReadOnlySpan<byte> back, ReadOnlySpan<byte> front,
+			int width, int height, PixelFormat format)
+		{
+			return EncodeCubeMapToKtxInternal(
+				ByteToColorMemory(right, width, height, format),
+				ByteToColorMemory(left, width, height, format),
+				ByteToColorMemory(top, width, height, format),
+				ByteToColorMemory(down, width, height, format),
+				ByteToColorMemory(back, width, height, format),
+				ByteToColorMemory(front, width, height, format), default);
+		}
+
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a <see cref="KtxFile"/>.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <returns>The encoded image as a <see cref="KtxFile"/>.</returns>
 		public KtxFile EncodeCubeMapToKtx(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
 			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
 			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front)
@@ -369,11 +496,145 @@ namespace BCnEncoder.Encoder
 			return EncodeCubeMapToKtxInternal(right, left, top, down, back, front, default);
 		}
 
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a <see cref="DdsFile"/>.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <param name="width">The width of the faces.</param>
+		/// <param name="height">The height of the faces.</param>
+		/// <param name="format">The pixel format the input data is in.</param>
+		/// <returns>The encoded image as a <see cref="DdsFile"/>.</returns>
+		public DdsFile EncodeCubeMapToDds(ReadOnlySpan<byte> right, ReadOnlySpan<byte> left,
+			ReadOnlySpan<byte> top, ReadOnlySpan<byte> down,
+			ReadOnlySpan<byte> back, ReadOnlySpan<byte> front,
+			int width, int height, PixelFormat format)
+		{
+			return EncodeCubeMapToDdsInternal(
+				ByteToColorMemory(right, width, height, format),
+				ByteToColorMemory(left, width, height, format),
+				ByteToColorMemory(top, width, height, format),
+				ByteToColorMemory(down, width, height, format),
+				ByteToColorMemory(back, width, height, format),
+				ByteToColorMemory(front, width, height, format), default);
+		}
+
+		/// <summary>
+		/// Encodes all mipMaps of a cubeMap image to a <see cref="DdsFile"/>.
+		/// The format can be set in <see cref="EncoderOutputOptions.FileFormat"/>.
+		/// Order of faces is +X, -X, +Y, -Y, +Z, -Z
+		/// </summary>
+		/// <param name="right">The positive X-axis face of the cubeMap</param>
+		/// <param name="left">The negative X-axis face of the cubeMap</param>
+		/// <param name="top">The positive Y-axis face of the cubeMap</param>
+		/// <param name="down">The negative Y-axis face of the cubeMap</param>
+		/// <param name="back">The positive Z-axis face of the cubeMap</param>
+		/// <param name="front">The negative Z-axis face of the cubeMap</param>
+		/// <returns>The encoded image as a <see cref="DdsFile"/>.</returns>
 		public DdsFile EncodeCubeMapToDds(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left,
 			ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
 			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front)
 		{
 			return EncodeCubeMapToDdsInternal(right, left, top, down, back, front, default);
+		}
+
+		/// <summary>
+		/// Encodes a single 4x4 block to raw encoded bytes. Input Span length must be exactly 16.
+		/// </summary>
+		/// <param name="inputBlock">Input 4x4 color block</param>
+		/// <returns>Raw encoded data</returns>
+		public byte[] EncodeBlock(ReadOnlySpan<ColorRgba32> inputBlock)
+		{
+			if (inputBlock.Length != 16)
+			{
+				throw new ArgumentException($"Single block encoding can only encode blocks of 4x4");
+			}
+			return EncodeBlockInternal(inputBlock.AsSpan2D(4, 4));
+		}
+
+		/// <summary>
+		/// Encodes a single 4x4 block to raw encoded bytes. Input Span width and height must be exactly 4.
+		/// </summary>
+		/// <param name="inputBlock">Input 4x4 color block</param>
+		/// <returns>Raw encoded data</returns>
+		public byte[] EncodeBlock(ReadOnlySpan2D<ColorRgba32> inputBlock)
+		{
+			if (inputBlock.Width != 4 || inputBlock.Height != 4)
+			{
+				throw new ArgumentException($"Single block encoding can only encode blocks of 4x4");
+			}
+			return EncodeBlockInternal(inputBlock);
+		}
+
+		/// <summary>
+		/// Encodes a single 4x4 block and writes the encoded block to a stream. Input Span length must be exactly 16.
+		/// </summary>
+		/// <param name="inputBlock">Input 4x4 color block</param>
+		/// <param name="outputStream">Output stream where the encoded block will be written to.</param>
+		public void EncodeBlock(ReadOnlySpan<ColorRgba32> inputBlock, Stream outputStream)
+		{
+			if (inputBlock.Length != 16)
+			{
+				throw new ArgumentException($"Single block encoding can only encode blocks of 4x4");
+			}
+			EncodeBlockInternal(inputBlock.AsSpan2D(4, 4), outputStream);
+		}
+
+		/// <summary>
+		/// Encodes a single 4x4 block and writes the encoded block to a stream. Input Span width and height must be exactly 4.
+		/// </summary>
+		/// <param name="inputBlock">Input 4x4 color block</param>
+		/// <param name="outputStream">Output stream where the encoded block will be written to.</param>
+		public void EncodeBlock(ReadOnlySpan2D<ColorRgba32> inputBlock, Stream outputStream)
+		{
+			if (inputBlock.Width != 4 || inputBlock.Height != 4)
+			{
+				throw new ArgumentException($"Single block encoding can only encode blocks of 4x4");
+			}
+			EncodeBlockInternal(inputBlock, outputStream);
+		}
+
+		/// <summary>
+		/// Gets the block size of the currently selected compression format in bytes.
+		/// </summary>
+		/// <returns>The size of a single 4x4 block in bytes</returns>
+		public int GetBlockSize()
+		{
+			var compressedEncoder = GetEncoder(OutputOptions.Format);
+			if (compressedEncoder == null)
+			{
+				throw new NotSupportedException($"This format is either not supported or does not use block compression: {OutputOptions.Format}");
+			}
+			return compressedEncoder.GetBlockSize();
+		}
+
+		/// <summary>
+		/// Gets the number of total blocks in an image with the given pixel width and height.
+		/// </summary>
+		/// <param name="pixelWidth">The pixel width of the image</param>
+		/// <param name="pixelHeight">The pixel height of the image</param>
+		/// <returns>The total number of blocks.</returns>
+		public int GetBlockCount(int pixelWidth, int pixelHeight)
+		{
+			return ImageToBlocks.CalculateNumOfBlocks(pixelWidth, pixelHeight);
+		}
+
+		/// <summary>
+		/// Gets the number of blocks in an image with the given pixel width and height.
+		/// </summary>
+		/// <param name="pixelWidth">The pixel width of the image</param>
+		/// <param name="pixelHeight">The pixel height of the image</param>
+		/// <param name="blocksWidth">The amount of blocks in the x-axis</param>
+		/// <param name="blocksHeight">The amount of blocks in the y-axis</param>
+		public void GetBlockCount(int pixelWidth, int pixelHeight, out int blocksWidth, out int blocksHeight)
+		{
+			ImageToBlocks.CalculateNumOfBlocks(pixelWidth, pixelHeight, out blocksWidth, out blocksHeight);
 		}
 
 		#endregion
@@ -532,13 +793,13 @@ namespace BCnEncoder.Encoder
 				}
 
 				var (ddsHeader, dxt10Header) = DdsHeader.InitializeCompressed(input.Width, input.Height,
-					compressedEncoder.GetDxgiFormat());
+					compressedEncoder.GetDxgiFormat(), OutputOptions.DdsPreferDxt10Header);
 				output = new DdsFile(ddsHeader, dxt10Header);
 
 				if (OutputOptions.DdsBc1WriteAlphaFlag &&
 					OutputOptions.Format == CompressionFormat.Bc1WithAlpha)
 				{
-					output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphapixels;
+					output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphaPixels;
 				}
 			}
 			else
@@ -890,13 +1151,13 @@ namespace BCnEncoder.Encoder
 				}
 
 				var (ddsHeader, dxt10Header) = DdsHeader.InitializeCompressed(width, height,
-					compressedEncoder.GetDxgiFormat());
+					compressedEncoder.GetDxgiFormat(), OutputOptions.DdsPreferDxt10Header);
 				output = new DdsFile(ddsHeader, dxt10Header);
 
 				if (OutputOptions.DdsBc1WriteAlphaFlag &&
 					OutputOptions.Format == CompressionFormat.Bc1WithAlpha)
 				{
-					output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphapixels;
+					output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphaPixels;
 				}
 			}
 			else
@@ -988,6 +1249,59 @@ namespace BCnEncoder.Encoder
 							  HeaderCaps2.Ddscaps2CubemapNegativez;
 
 			return output;
+		}
+
+		private byte[] EncodeBlockInternal(ReadOnlySpan2D<ColorRgba32> input)
+		{
+			var compressedEncoder = GetEncoder(OutputOptions.Format);
+			if (compressedEncoder == null)
+			{
+				throw new NotSupportedException($"This Format is not supported for single block encoding: {OutputOptions.Format}");
+			}
+
+			var output = new byte[compressedEncoder.GetBlockSize()];
+
+			var rawBlock = new RawBlock4X4Rgba32();
+
+			var pixels = rawBlock.AsSpan;
+
+			input.GetRowSpan(0).CopyTo(pixels);
+			input.GetRowSpan(1).CopyTo(pixels.Slice(4));
+			input.GetRowSpan(2).CopyTo(pixels.Slice(8));
+			input.GetRowSpan(3).CopyTo(pixels.Slice(12));
+
+			compressedEncoder.EncodeBlock(rawBlock, OutputOptions.Quality, output);
+
+			return output;
+		}
+
+		private void EncodeBlockInternal(ReadOnlySpan2D<ColorRgba32> input, Stream outputStream)
+		{
+			var compressedEncoder = GetEncoder(OutputOptions.Format);
+			if (compressedEncoder == null)
+			{
+				throw new NotSupportedException($"This Format is not supported for single block encoding: {OutputOptions.Format}");
+			}
+			if (input.Width != 4 || input.Height != 4)
+			{
+				throw new ArgumentException($"Single block encoding can only encode blocks of 4x4");
+			}
+
+			Span<byte> output = stackalloc byte[16];
+			output = output.Slice(0, compressedEncoder.GetBlockSize());
+
+			var rawBlock = new RawBlock4X4Rgba32();
+
+			var pixels = rawBlock.AsSpan;
+
+			input.GetRowSpan(0).CopyTo(pixels);
+			input.GetRowSpan(1).CopyTo(pixels.Slice(4));
+			input.GetRowSpan(2).CopyTo(pixels.Slice(8));
+			input.GetRowSpan(3).CopyTo(pixels.Slice(12));
+
+			compressedEncoder.EncodeBlock(rawBlock, OutputOptions.Quality, output);
+
+			outputStream.Write(output);
 		}
 
 		#endregion
@@ -1089,7 +1403,7 @@ namespace BCnEncoder.Encoder
 					break;
 			}
 
-			return new ReadOnlyMemory2D<ColorRgba32>(pixels, width, height);
+			return new ReadOnlyMemory2D<ColorRgba32>(pixels, height, width);
 		}
 
 		#endregion

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -28,6 +28,11 @@ namespace BCnEncoder.Encoder
 		Bgra32,
 
 		/// <summary>
+		/// Specifies the ARGB32 layout.
+		/// </summary>
+		Argb32,
+
+		/// <summary>
 		/// Specifies the RGB24 layout.
 		/// </summary>
 		Rgb24,
@@ -211,12 +216,12 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream.
 		/// </summary>
-		/// <param name="input">The input to encode represented by a <see cref="Memory{T}"/>.</param>
+		/// <param name="input">The input to encode represented by a <see cref="ReadOnlyMemory{T}"/>.</param>
 		/// <param name="width">The width of the image.</param>
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		public void EncodeToStream(Memory<byte> input, int width, int height, PixelFormat format, Stream outputStream)
+		public void EncodeToStream(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, Stream outputStream)
 		{
 			EncodeToStream(ByteToColorMemory(input.Span, width, height, format), outputStream);
 		}
@@ -226,7 +231,7 @@ namespace BCnEncoder.Encoder
 		/// </summary>
 		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		public void EncodeToStream(Memory2D<ColorRgba32> input, Stream outputStream)
+		public void EncodeToStream(ReadOnlyMemory2D<ColorRgba32> input, Stream outputStream)
 		{
 			EncodeToStreamInternal(input, outputStream, default);
 		}
@@ -239,7 +244,7 @@ namespace BCnEncoder.Encoder
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
 		/// <returns>The Ktx file containing the encoded image.</returns>
-		public KtxFile EncodeToKtx(Memory<byte> input, int width, int height, PixelFormat format)
+		public KtxFile EncodeToKtx(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format)
 		{
 			return EncodeToKtx(ByteToColorMemory(input.Span, width, height, format));
 		}
@@ -249,7 +254,7 @@ namespace BCnEncoder.Encoder
 		/// </summary>
 		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>The Ktx file containing the encoded image.</returns>
-		public KtxFile EncodeToKtx(Memory2D<ColorRgba32> input)
+		public KtxFile EncodeToKtx(ReadOnlyMemory2D<ColorRgba32> input)
 		{
 			return EncodeToKtxInternal(input, default);
 		}
@@ -262,7 +267,7 @@ namespace BCnEncoder.Encoder
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
 		/// <returns>The Dds file containing the encoded image.</returns>
-		public DdsFile EncodeToDds(Memory<byte> input, int width, int height, PixelFormat format)
+		public DdsFile EncodeToDds(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format)
 		{
 			return EncodeToDds(ByteToColorMemory(input.Span, width, height, format));
 		}
@@ -272,7 +277,7 @@ namespace BCnEncoder.Encoder
 		/// </summary>
 		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>The Dds file containing the encoded image.</returns>
-		public DdsFile EncodeToDds(Memory2D<ColorRgba32> input)
+		public DdsFile EncodeToDds(ReadOnlyMemory2D<ColorRgba32> input)
 		{
 			return EncodeToDdsInternal(input, default);
 		}
@@ -285,7 +290,7 @@ namespace BCnEncoder.Encoder
 		/// <param name="height">The height of the image.</param>
 		/// <param name="format">The pixel format the given data is in.</param>
 		/// <returns>A list of raw encoded mipmap input.</returns>
-		public byte[][] EncodeToRawBytes(Memory<byte> input, int width, int height, PixelFormat format)
+		public byte[][] EncodeToRawBytes(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format)
 		{
 			return EncodeToRawBytes(ByteToColorMemory(input.Span, width, height, format));
 		}
@@ -295,7 +300,7 @@ namespace BCnEncoder.Encoder
 		/// </summary>
 		/// <param name="input">The input to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>A list of raw encoded mipmap input.</returns>
-		public byte[][] EncodeToRawBytes(Memory2D<ColorRgba32> input)
+		public byte[][] EncodeToRawBytes(ReadOnlyMemory2D<ColorRgba32> input)
 		{
 			return EncodeToRawInternal(input, default);
 		}
@@ -311,7 +316,7 @@ namespace BCnEncoder.Encoder
 		/// <param name="mipWidth">The width of the mipmap.</param>
 		/// <param name="mipHeight">The height of the mipmap.</param>
 		/// <returns>The raw encoded input.</returns>
-		public byte[] EncodeToRawBytes(Memory<byte> input, int width, int height, PixelFormat format, int mipLevel, out int mipWidth, out int mipHeight)
+		public byte[] EncodeToRawBytes(ReadOnlyMemory<byte> input, int width, int height, PixelFormat format, int mipLevel, out int mipWidth, out int mipHeight)
 		{
 			return EncodeToRawInternal(ByteToColorMemory(input.Span, width, height, format), mipLevel, out mipWidth, out mipHeight, default);
 		}
@@ -324,7 +329,7 @@ namespace BCnEncoder.Encoder
 		/// <param name="mipWidth">The width of the mipmap.</param>
 		/// <param name="mipHeight">The height of the mipmap.</param>
 		/// <returns>The raw encoded input.</returns>
-		public byte[] EncodeToRawBytes(Memory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight)
+		public byte[] EncodeToRawBytes(ReadOnlyMemory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight)
 		{
 			return EncodeToRawInternal(input, mipLevel, out mipWidth, out mipHeight, default);
 		}
@@ -363,7 +368,7 @@ namespace BCnEncoder.Encoder
 
 		#region Private
 
-		private void EncodeToStreamInternal(Memory2D<ColorRgba32> input, Stream outputStream, CancellationToken token)
+		private void EncodeToStreamInternal(ReadOnlyMemory2D<ColorRgba32> input, Stream outputStream, CancellationToken token)
 		{
 			switch (OutputOptions.FileFormat)
 			{
@@ -379,7 +384,7 @@ namespace BCnEncoder.Encoder
 			}
 		}
 
-		private KtxFile EncodeToKtxInternal(Memory2D<ColorRgba32> input, CancellationToken token)
+		private KtxFile EncodeToKtxInternal(ReadOnlyMemory2D<ColorRgba32> input, CancellationToken token)
 		{
 			KtxFile output;
 			IBcBlockEncoder compressedEncoder = null;
@@ -465,7 +470,7 @@ namespace BCnEncoder.Encoder
 			return output;
 		}
 
-		private DdsFile EncodeToDdsInternal(Memory2D<ColorRgba32> input, CancellationToken token)
+		private DdsFile EncodeToDdsInternal(ReadOnlyMemory2D<ColorRgba32> input, CancellationToken token)
 		{
 			DdsFile output;
 			IBcBlockEncoder compressedEncoder = null;
@@ -557,7 +562,7 @@ namespace BCnEncoder.Encoder
 			return output;
 		}
 
-		private byte[][] EncodeToRawInternal(Memory2D<ColorRgba32> input, CancellationToken token)
+		private byte[][] EncodeToRawInternal(ReadOnlyMemory2D<ColorRgba32> input, CancellationToken token)
 		{
 			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
 			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
@@ -622,7 +627,7 @@ namespace BCnEncoder.Encoder
 			return output;
 		}
 
-		private byte[] EncodeToRawInternal(Memory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
+		private byte[] EncodeToRawInternal(ReadOnlyMemory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
 		{
 			mipLevel = Math.Max(0, mipLevel);
 
@@ -687,10 +692,8 @@ namespace BCnEncoder.Encoder
 			return encoded;
 		}
 
-		// TODO: Do we still need cubemap methods? If yes, expose them in both Sync and Async API
-
-		private void EncodeCubeMapToStreamInternal(Memory2D<ColorRgba32> right, Memory2D<ColorRgba32> left, Memory2D<ColorRgba32> top, Memory2D<ColorRgba32> down,
-			Memory2D<ColorRgba32> back, Memory2D<ColorRgba32> front, Stream outputStream, CancellationToken token)
+		private void EncodeCubeMapToStreamInternal(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left, ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, Stream outputStream, CancellationToken token)
 		{
 			switch (OutputOptions.FileFormat)
 			{
@@ -706,8 +709,8 @@ namespace BCnEncoder.Encoder
 			}
 		}
 
-		private KtxFile EncodeCubeMapToKtxInternal(Memory2D<ColorRgba32> right, Memory2D<ColorRgba32> left, Memory2D<ColorRgba32> top, Memory2D<ColorRgba32> down,
-			Memory2D<ColorRgba32> back, Memory2D<ColorRgba32> front, CancellationToken token)
+		private KtxFile EncodeCubeMapToKtxInternal(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left, ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, CancellationToken token)
 		{
 			KtxFile output;
 			IBcBlockEncoder compressedEncoder = null;
@@ -822,8 +825,8 @@ namespace BCnEncoder.Encoder
 			return output;
 		}
 
-		private DdsFile EncodeCubeMapToDdsInternal(Memory2D<ColorRgba32> right, Memory2D<ColorRgba32> left, Memory2D<ColorRgba32> top, Memory2D<ColorRgba32> down,
-			Memory2D<ColorRgba32> back, Memory2D<ColorRgba32> front, CancellationToken token)
+		private DdsFile EncodeCubeMapToDdsInternal(ReadOnlyMemory2D<ColorRgba32> right, ReadOnlyMemory2D<ColorRgba32> left, ReadOnlyMemory2D<ColorRgba32> top, ReadOnlyMemory2D<ColorRgba32> down,
+			ReadOnlyMemory2D<ColorRgba32> back, ReadOnlyMemory2D<ColorRgba32> front, CancellationToken token)
 		{
 			DdsFile output;
 			IBcBlockEncoder compressedEncoder = null;
@@ -1012,7 +1015,7 @@ namespace BCnEncoder.Encoder
 			}
 		}
 
-		private Memory2D<ColorRgba32> ByteToColorMemory(Span<byte> span, int width, int height, PixelFormat format)
+		private ReadOnlyMemory2D<ColorRgba32> ByteToColorMemory(ReadOnlySpan<byte> span, int width, int height, PixelFormat format)
 		{
 			var pixels = new ColorRgba32[width * height];
 
@@ -1037,9 +1040,14 @@ namespace BCnEncoder.Encoder
 					for (var i = 0; i < width * height * 3; i += 3)
 						pixels[i / 3] = new ColorRgba32(span[i + 2], span[i + 1], span[i], 255);
 					break;
+
+				case PixelFormat.Argb32:
+					for (var i = 0; i < width * height * 4; i += 4)
+						pixels[i / 4] = new ColorRgba32(span[i + 1], span[i + 2], span[i + 3], span[i]);
+					break;
 			}
 
-			return new Memory2D<ColorRgba32>(pixels, width, height);
+			return new ReadOnlyMemory2D<ColorRgba32>(pixels, width, height);
 		}
 
 		#endregion

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using BCnEncoder.Encoder.Bc7;
 using BCnEncoder.Encoder.Options;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using Microsoft.Toolkit.HighPerformance.Memory;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -11,6 +11,7 @@ using BCnEncoder.Encoder.Bc7;
 using BCnEncoder.Encoder.Options;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
+using Microsoft.Toolkit.HighPerformance.Extensions;
 using Microsoft.Toolkit.HighPerformance.Memory;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -301,202 +302,54 @@ namespace BCnEncoder.Encoder
 		/// <summary>
 		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		public void EncodeToStream<T>(Memory<T> inputPixelsRgba, int width, int height, Stream outputStream) where T : unmanaged
+		public void EncodeToStream(Memory2D<ColorRgba32> input, Stream outputStream)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			EncodeToStreamInternal(bytes, width, height, outputStream, default);
+			EncodeToStreamInternal(input, outputStream, default);
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a Ktx file.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>The Ktx file containing the encoded image.</returns>
-		public KtxFile EncodeToKtx<T>(Memory<T> inputPixelsRgba, int width, int height) where T : unmanaged
+		public KtxFile EncodeToKtx(Memory2D<ColorRgba32> input)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToKtxInternal(bytes, width, height, default);
+			return EncodeToKtxInternal(input, default);
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a Dds file.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>The Dds file containing the encoded image.</returns>
-		public DdsFile EncodeToDds<T>(Memory<T> inputPixelsRgba, int width, int height) where T : unmanaged
+		public DdsFile EncodeToDds<T>(Memory2D<ColorRgba32> input)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToDdsInternal(bytes, width, height, default);
+			return EncodeToDdsInternal(input, default);
 		}
 
 		/// <summary>
 		/// Encodes all mipmap levels into a list of byte buffers.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <returns>A list of raw encoded mipmap data.</returns>
-		public IList<byte[]> EncodeToRawBytes<T>(Memory<T> inputPixelsRgba, int width, int height) where T : unmanaged
+		public byte[][] EncodeToRawBytes(Memory2D<ColorRgba32> input)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToRawBytesInternal(bytes, width, height, default);
+			return EncodeToRawBytesInternal(input, default);
 		}
 
 		/// <summary>
 		/// Encodes a single mip level of the input image to a byte buffer.
 		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <param name="width">The width of the input image.</param>
-		/// <param name="height">The height of the input image.</param>
+		/// <param name="input">The data to encode represented by a <see cref="Memory2D{T}"/>.</param>
 		/// <param name="mipLevel">The mipmap to encode.</param>
 		/// <param name="mipWidth">The width of the mipmap.</param>
 		/// <param name="mipHeight">The height of the mipmap.</param>
 		/// <returns>The raw encoded data.</returns>
-		public byte[] EncodeToRawBytes<T>(Memory<T> inputPixelsRgba, int width, int height, int mipLevel, out int mipWidth, out int mipHeight) where T : unmanaged
+		public byte[] EncodeToRawBytes(Memory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight)
 		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			var bytes = MemoryMarshal.AsBytes(inputPixelsRgba.Span);
-			return EncodeToRawBytesInternal(bytes, width, height, mipLevel, out mipWidth,
-				out mipHeight, default);
-		}
-
-
-
-		/// <summary>
-		/// Encodes all mipmap levels into a ktx or a dds file and writes it to the output stream.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <param name="outputStream">The stream to write the encoded image to.</param>
-		public void EncodeToStream<T>(Memory2D<T> inputPixelsRgba, Stream outputStream) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			EncodeToStreamInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, outputStream, default);
-		}
-
-		/// <summary>
-		/// Encodes all mipmap levels into a Ktx file.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <returns>The Ktx file containing the encoded image.</returns>
-		public KtxFile EncodeToKtx<T>(Memory2D<T> inputPixelsRgba) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			return EncodeToKtxInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, default);
-		}
-
-		/// <summary>
-		/// Encodes all mipmap levels into a Dds file.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The input image rgba data.</param>
-		/// <returns>The Dds file containing the encoded image.</returns>
-		public DdsFile EncodeToDds<T>(Memory2D<T> inputPixelsRgba) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			return EncodeToDdsInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, default);
-		}
-
-		/// <summary>
-		/// Encodes all mipmap levels into a list of byte buffers.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <returns>A list of raw encoded mipmap data.</returns>
-		public IList<byte[]> EncodeToRawBytes<T>(Memory2D<T> inputPixelsRgba) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			return EncodeToRawBytesInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, default);
-		}
-
-		/// <summary>
-		/// Encodes a single mip level of the input image to a byte buffer.
-		/// </summary>
-		/// <param name="inputPixelsRgba">The raw pixels of the input image in rgba format.</param>
-		/// <param name="mipLevel">The mipmap to encode.</param>
-		/// <param name="mipWidth">The width of the mipmap.</param>
-		/// <param name="mipHeight">The height of the mipmap.</param>
-		/// <returns>The raw encoded data.</returns>
-		public byte[] EncodeToRawBytes<T>(Memory2D<T> inputPixelsRgba, int mipLevel, out int mipWidth, out int mipHeight) where T : unmanaged
-		{
-			if (Unsafe.SizeOf<T>() != 4 || Unsafe.SizeOf<T>() != 1)
-			{
-				throw new ArgumentException(
-					"The input pixels should be given in either byte format or a 4-byte rgba wrapper");
-			}
-			if (!inputPixelsRgba.Span.TryGetSpan(out var span))
-			{
-				throw new ArgumentException("Unable to get a Span out of Memory2D. Is the underlying buffer contiguous?");
-			}
-			var bytes = MemoryMarshal.AsBytes(span);
-			
-			return EncodeToRawBytesInternal(bytes, inputPixelsRgba.Width, inputPixelsRgba.Height, mipLevel, out mipWidth,
-				out mipHeight, default);
+			return EncodeToRawBytesInternal(input, mipLevel, out mipWidth, out mipHeight, default);
 		}
 
 		#endregion
@@ -533,408 +386,403 @@ namespace BCnEncoder.Encoder
 
 		#region Private
 
-		private void EncodeToStreamInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, Stream outputStream, CancellationToken token)
+		private void EncodeToStreamInternal(Memory<ColorRgba32> input, int width, int height, Stream outputStream, CancellationToken token)
+		{
+			EncodeToStreamInternal(input.AsMemory2D(width, height), outputStream, token);
+		}
+
+		private void EncodeToStreamInternal(Memory2D<ColorRgba32> input, Stream outputStream, CancellationToken token)
 		{
 			switch (OutputOptions.FileFormat)
 			{
 				case OutputFileFormat.Dds:
-					var dds = EncodeToDdsInternal(inputPixelsRgba, width, height, token);
+					var dds = EncodeToDdsInternal(input, token);
 					dds.Write(outputStream);
 					break;
 
 				case OutputFileFormat.Ktx:
-					var ktx = EncodeToKtxInternal(inputPixelsRgba, width, height, token);
+					var ktx = EncodeToKtxInternal(input, token);
 					ktx.Write(outputStream);
 					break;
 			}
 		}
 
-		private KtxFile EncodeToKtxInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, CancellationToken token)
+		private KtxFile EncodeToKtxInternal(Memory<ColorRgba32> input, int width, int height, CancellationToken token)
+		{
+			return EncodeToKtxInternal(input.AsMemory2D(width, height), token);
+		}
+
+		private KtxFile EncodeToKtxInternal(Memory2D<ColorRgba32> input, CancellationToken token)
 		{
 			KtxFile output;
 			IBcBlockEncoder compressedEncoder = null;
 			IRawEncoder uncompressedEncoder = null;
 
 			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			// Setup encoders
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+			if (isCompressedFormat)
 			{
-				// Setup encoders
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
+				{
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
+				}
+
+				output = new KtxFile(
+					KtxHeader.InitializeCompressed(input.Width, input.Height,
+						compressedEncoder.GetInternalFormat(),
+						compressedEncoder.GetBaseInternalFormat()));
+			}
+			else
+			{
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+				output = new KtxFile(
+					KtxHeader.InitializeUncompressed(input.Width, input.Height,
+						uncompressedEncoder.GetGlType(),
+						uncompressedEncoder.GetGlFormat(),
+						uncompressedEncoder.GetGlTypeSize(),
+						uncompressedEncoder.GetInternalFormat(),
+						uncompressedEncoder.GetBaseInternalFormat()));
+			}
+
+			var context = new OperationContext
+			{
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
+
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
+
+			// Encode mipmap levels
+			for (var mip = 0; mip < numMipMaps; mip++)
+			{
+				byte[] encoded;
 				if (isCompressedFormat)
 				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
+					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip], out var blocksWidth,
+						out var blocksHeight);
+					encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality,
+						context);
 
-					output = new KtxFile(
-						KtxHeader.InitializeCompressed(width, height,
-							compressedEncoder.GetInternalFormat(),
-							compressedEncoder.GetBaseInternalFormat()));
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
 				}
 				else
 				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-					output = new KtxFile(
-						KtxHeader.InitializeUncompressed(width, height,
-							uncompressedEncoder.GetGlType(),
-							uncompressedEncoder.GetGlFormat(),
-							uncompressedEncoder.GetGlTypeSize(),
-							uncompressedEncoder.GetInternalFormat(),
-							uncompressedEncoder.GetBaseInternalFormat()));
-				}
-
-				var context = new OperationContext
-				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode mipmap levels
-				for (var mip = 0; mip < numMipMaps; mip++)
-				{
-					byte[] encoded;
-					if (isCompressedFormat)
+					if (!mipChain[mip].TryGetMemory(out var mipMemory))
 					{
-						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth,
-							out var blocksHeight);
-						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality,
-							context);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
-					}
-					else
-					{
-						if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-							throw new Exception("Cannot get pixel span.");
-
-						encoded = uncompressedEncoder.Encode(mipPixels);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
+						throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
 					}
 
-					output.MipMaps.Add(new KtxMipmap((uint)encoded.Length,
-						(uint)mipChain[mip].Width,
-						(uint)mipChain[mip].Height, 1));
-					output.MipMaps[mip].Faces[0] = new KtxMipFace(encoded,
-						(uint)mipChain[mip].Width,
-						(uint)mipChain[mip].Height);
+					encoded = uncompressedEncoder.Encode(mipMemory);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
 				}
 
-				output.header.NumberOfFaces = 1;
-				output.header.NumberOfMipmapLevels = (uint)numMipMaps;
+				output.MipMaps.Add(new KtxMipmap((uint)encoded.Length,
+					(uint)mipChain[mip].Width,
+					(uint)mipChain[mip].Height, 1));
+				output.MipMaps[mip].Faces[0] = new KtxMipFace(encoded,
+					(uint)mipChain[mip].Width,
+					(uint)mipChain[mip].Height);
+			}
 
-				return output;
-			}
-			finally
-			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
-			}
+			output.header.NumberOfFaces = 1;
+			output.header.NumberOfMipmapLevels = (uint)numMipMaps;
+
+			return output;
 		}
 
-		private DdsFile EncodeToDdsInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, CancellationToken token)
+		private DdsFile EncodeToDdsInternal(Memory<ColorRgba32> input, int width, int height, CancellationToken token)
+		{
+			return EncodeToDdsInternal(input.AsMemory2D(width, height), token);
+		}
+
+		private DdsFile EncodeToDdsInternal(Memory2D<ColorRgba32> input, CancellationToken token)
 		{
 			DdsFile output;
 			IBcBlockEncoder compressedEncoder = null;
 			IRawEncoder uncompressedEncoder = null;
 
 			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			// Setup encoder
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+			if (isCompressedFormat)
 			{
-				// Setup encoder
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
-				if (isCompressedFormat)
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
 				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
-
-					var (ddsHeader, dxt10Header) = DdsHeader.InitializeCompressed(width, height,
-						compressedEncoder.GetDxgiFormat());
-					output = new DdsFile(ddsHeader, dxt10Header);
-
-					if (OutputOptions.DdsBc1WriteAlphaFlag &&
-						OutputOptions.Format == CompressionFormat.Bc1WithAlpha)
-					{
-						output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphapixels;
-					}
-				}
-				else
-				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-					var ddsHeader = DdsHeader.InitializeUncompressed(width, height,
-						uncompressedEncoder.GetDxgiFormat());
-					output = new DdsFile(ddsHeader);
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
 				}
 
-				var context = new OperationContext
+				var (ddsHeader, dxt10Header) = DdsHeader.InitializeCompressed(input.Width, input.Height,
+					compressedEncoder.GetDxgiFormat());
+				output = new DdsFile(ddsHeader, dxt10Header);
+
+				if (OutputOptions.DdsBc1WriteAlphaFlag &&
+					OutputOptions.Format == CompressionFormat.Bc1WithAlpha)
 				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode mipmap levels
-				for (var mip = 0; mip < numMipMaps; mip++)
-				{
-					byte[] encoded;
-					if (isCompressedFormat)
-					{
-						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth, out var blocksHeight);
-						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
-					}
-					else
-					{
-						if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-						{
-							throw new Exception("Cannot get pixel span.");
-						}
-
-						encoded = uncompressedEncoder.Encode(mipPixels);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
-					}
-
-					if (mip == 0)
-					{
-						output.Faces.Add(new DdsFace((uint)width, (uint)height,
-							(uint)encoded.Length, (int)numMipMaps));
-					}
-
-					output.Faces[0].MipMaps[mip] = new DdsMipMap(encoded,
-						(uint)mipChain[mip].Width,
-						(uint)mipChain[mip].Height);
+					output.header.ddsPixelFormat.dwFlags |= PixelFormatFlags.DdpfAlphapixels;
 				}
-
-
-				output.header.dwMipMapCount = (uint)numMipMaps;
-				if (numMipMaps > 1)
-				{
-					output.header.dwCaps |= HeaderCaps.DdscapsComplex | HeaderCaps.DdscapsMipmap;
-				}
-
-				return output;
 			}
-			finally
+			else
 			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
-			}
-		}
-
-		private IList<byte[]> EncodeToRawBytesInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, CancellationToken token)
-		{
-			if (inputPixelsRgba.Length != width * height * 4)
-			{
-				throw new ArgumentException("The input pixels must be provided in 4 bytes per pixel rgba format.");
-			}
-			
-			var output = new List<byte[]>();
-			IBcBlockEncoder compressedEncoder = null;
-			IRawEncoder uncompressedEncoder = null;
-
-			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
-			{
-				// Setup encoder
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
-
-				if (isCompressedFormat)
-				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
-				}
-				else
-				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-				}
-
-				var context = new OperationContext
-				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode all mipmap levels
-				for (var mip = 0; mip < numMipMaps; mip++)
-				{
-					byte[] encoded;
-					if (isCompressedFormat)
-					{
-						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth, out var blocksHeight);
-						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
-					}
-					else
-					{
-						if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-						{
-							throw new Exception("Cannot get pixel span.");
-						}
-
-						encoded = uncompressedEncoder.Encode(mipPixels);
-
-						context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
-					}
-
-					output.Add(encoded);
-				}
-
-
-				return output;
-			}
-			finally
-			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
-			}
-		}
-
-		private byte[] EncodeToRawBytesInternal(ReadOnlySpan<byte> inputPixelsRgba, int width, int height, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
-		{
-			if (inputPixelsRgba.Length != width * height * 4)
-			{
-				throw new ArgumentException("The input pixels must be provided in 4 bytes per pixel rgba format.");
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+				var ddsHeader = DdsHeader.InitializeUncompressed(input.Width, input.Height,
+					uncompressedEncoder.GetDxgiFormat());
+				output = new DdsFile(ddsHeader);
 			}
 
-			if (mipLevel < 0)
-				throw new ArgumentException($"{nameof(mipLevel)} cannot be less than zero.");
-
-			IBcBlockEncoder compressedEncoder = null;
-			IRawEncoder uncompressedEncoder = null;
-
-			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipChain = MipMapper.GenerateMipChain(inputPixelsRgba, width, height, ref numMipMaps);
-			try
+			var context = new OperationContext
 			{
-				// Setup encoder
-				var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
-				if (isCompressedFormat)
-				{
-					compressedEncoder = GetEncoder(OutputOptions.Format);
-					if (compressedEncoder == null)
-					{
-						throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
-					}
-				}
-				else
-				{
-					uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
-				}
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
 
-				// Dispose all mipmap levels
-				if (mipLevel > numMipMaps - 1)
-				{
-					throw new ArgumentException($"{nameof(mipLevel)} cannot be more than number of mipmaps.");
-				}
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
 
-				var context = new OperationContext
-				{
-					CancellationToken = token,
-					IsParallel = !Debugger.IsAttached && Options.IsParallel,
-					TaskCount = Options.TaskCount
-				};
-
-				// Calculate total blocks
-				var totalBlocks = isCompressedFormat ? ImageToBlocks.CalculateNumOfBlocks(mipChain[mipLevel].Width, mipChain[mipLevel].Height) : mipChain[mipLevel].Width * mipChain[mipLevel].Height;
-				context.Progress = new OperationProgress(Options.Progress, totalBlocks);
-
-				// Encode mipmap level
+			// Encode mipmap levels
+			for (var mip = 0; mip < numMipMaps; mip++)
+			{
 				byte[] encoded;
 				if (isCompressedFormat)
 				{
-					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mipLevel].Frames[0], out var blocksWidth, out var blocksHeight);
+					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip], out var blocksWidth, out var blocksHeight);
 					encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
 				}
 				else
 				{
-					if (!mipChain[mipLevel].TryGetSinglePixelSpan(out var mipPixels))
+					if (!mipChain[mip].TryGetMemory(out var mipMemory))
 					{
-						throw new Exception("Cannot get pixel span.");
+						throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
 					}
 
-					encoded = uncompressedEncoder.Encode(mipPixels);
+					encoded = uncompressedEncoder.Encode(mipMemory);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
 				}
 
-				mipWidth = mipChain[mipLevel].Width;
-				mipHeight = mipChain[mipLevel].Height;
+				if (mip == 0)
+				{
+					output.Faces.Add(new DdsFace((uint)input.Width, (uint)input.Height,
+						(uint)encoded.Length, numMipMaps));
+				}
 
-				return encoded;
+				output.Faces[0].MipMaps[mip] = new DdsMipMap(encoded,
+					(uint)mipChain[mip].Width,
+					(uint)mipChain[mip].Height);
 			}
-			finally
+
+
+			output.header.dwMipMapCount = (uint)numMipMaps;
+			if (numMipMaps > 1)
 			{
-				// Dispose all mipmap levels, even if operation was cancelled
-				foreach (var image in mipChain)
-					image.Dispose();
+				output.header.dwCaps |= HeaderCaps.DdscapsComplex | HeaderCaps.DdscapsMipmap;
 			}
+
+			return output;
 		}
 
-		private void EncodeCubeMapToStreamInternal(ReadOnlySpan<byte> right, ReadOnlySpan<byte> left, ReadOnlySpan<byte> top, ReadOnlySpan<byte> down,
-			ReadOnlySpan<byte> back, ReadOnlySpan<byte> front, int width, int height, Stream outputStream, CancellationToken token)
+		private IList<byte[]> EncodeToRawInternal(Memory<ColorRgba32> input, int width, int height, CancellationToken token)
+		{
+			return EncodeToRawInternal(input.AsMemory2D(width, height), token);
+		}
+
+		private IList<byte[]> EncodeToRawInternal(Memory2D<ColorRgba32> input, CancellationToken token)
+		{
+			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			var output = new List<byte[]>(numMipMaps);
+			IBcBlockEncoder compressedEncoder = null;
+			IRawEncoder uncompressedEncoder = null;
+
+			// Setup encoder
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+
+			if (isCompressedFormat)
+			{
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
+				{
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
+				}
+			}
+			else
+			{
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+			}
+
+			var context = new OperationContext
+			{
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
+
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? mipChain.Sum(m => ImageToBlocks.CalculateNumOfBlocks(m.Width, m.Height)) : mipChain.Sum(m => m.Width * m.Height);
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
+
+			// Encode all mipmap levels
+			for (var mip = 0; mip < numMipMaps; mip++)
+			{
+				byte[] encoded;
+				if (isCompressedFormat)
+				{
+					var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip], out var blocksWidth, out var blocksHeight);
+					encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => ImageToBlocks.CalculateNumOfBlocks(x.Width, x.Height)));
+				}
+				else
+				{
+					if (!mipChain[mip].TryGetMemory(out var mipMemory))
+					{
+						throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
+					}
+
+					encoded = uncompressedEncoder.Encode(mipMemory);
+
+					context.Progress.SetProcessedBlocks(mipChain.Take(mip + 1).Sum(x => x.Width * x.Height));
+				}
+
+				output.Add(encoded);
+			}
+
+			return output;
+		}
+
+		private byte[] EncodeToRawInternal(Memory<ColorRgba32> input, int width, int height, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
+		{
+			return EncodeToRawInternal(input.AsMemory2D(width, height), mipLevel, out mipWidth, out mipHeight, token);
+		}
+
+		private byte[] EncodeToRawInternal(Memory2D<ColorRgba32> input, int mipLevel, out int mipWidth, out int mipHeight, CancellationToken token)
+		{
+			mipLevel = Math.Max(0, mipLevel);
+
+			IBcBlockEncoder compressedEncoder = null;
+			IRawEncoder uncompressedEncoder = null;
+
+			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
+			var mipChain = MipMapper.GenerateMipChain(input, ref numMipMaps);
+
+			// Setup encoder
+			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
+			if (isCompressedFormat)
+			{
+				compressedEncoder = GetEncoder(OutputOptions.Format);
+				if (compressedEncoder == null)
+				{
+					throw new NotSupportedException($"This Format is not supported: {OutputOptions.Format}");
+				}
+			}
+			else
+			{
+				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
+			}
+
+			// Dispose all mipmap levels
+			if (mipLevel > numMipMaps - 1)
+			{
+				throw new ArgumentException($"{nameof(mipLevel)} cannot be more than number of mipmaps.");
+			}
+
+			var context = new OperationContext
+			{
+				CancellationToken = token,
+				IsParallel = !Debugger.IsAttached && Options.IsParallel,
+				TaskCount = Options.TaskCount
+			};
+
+			// Calculate total blocks
+			var totalBlocks = isCompressedFormat ? ImageToBlocks.CalculateNumOfBlocks(mipChain[mipLevel].Width, mipChain[mipLevel].Height) : mipChain[mipLevel].Width * mipChain[mipLevel].Height;
+			context.Progress = new OperationProgress(Options.Progress, totalBlocks);
+
+			// Encode mipmap level
+			byte[] encoded;
+			if (isCompressedFormat)
+			{
+				var blocks = ImageToBlocks.ImageTo4X4(mipChain[mipLevel], out var blocksWidth, out var blocksHeight);
+				encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+			}
+			else
+			{
+				if (!mipChain[mipLevel].TryGetMemory(out var mipMemory))
+				{
+					throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
+				}
+
+				encoded = uncompressedEncoder.Encode(mipMemory);
+			}
+
+			mipWidth = mipChain[mipLevel].Width;
+			mipHeight = mipChain[mipLevel].Height;
+
+			return encoded;
+		}
+
+		private void EncodeCubeMapToStreamInternal(Memory<ColorRgba32> right, Memory<ColorRgba32> left, Memory<ColorRgba32> top, Memory<ColorRgba32> down,
+			Memory<ColorRgba32> back, Memory<ColorRgba32> front, int width, int height, Stream outputStream, CancellationToken token)
+		{
+			EncodeCubeMapToStreamInternal(
+				right.AsMemory2D(width, height), left.AsMemory2D(width, height),
+				top.AsMemory2D(width, height), down.AsMemory2D(width, height),
+				back.AsMemory2D(width, height), front.AsMemory2D(width, height),
+				outputStream, token);
+		}
+
+		private void EncodeCubeMapToStreamInternal(Memory2D<ColorRgba32> right, Memory2D<ColorRgba32> left, Memory2D<ColorRgba32> top, Memory2D<ColorRgba32> down,
+			Memory2D<ColorRgba32> back, Memory2D<ColorRgba32> front, Stream outputStream, CancellationToken token)
 		{
 			switch (OutputOptions.FileFormat)
 			{
 				case OutputFileFormat.Ktx:
-					var ktx = EncodeCubeMapToKtxInternal(right, left, top, down, back, front, width, height, token);
+					var ktx = EncodeCubeMapToKtxInternal(right, left, top, down, back, front, token);
 					ktx.Write(outputStream);
 					break;
 
 				case OutputFileFormat.Dds:
-					var dds = EncodeCubeMapToDdsInternal(right, left, top, down, back, front, width, height, token);
+					var dds = EncodeCubeMapToDdsInternal(right, left, top, down, back, front, token);
 					dds.Write(outputStream);
 					break;
 			}
 		}
 
-		private KtxFile EncodeCubeMapToKtxInternal(ReadOnlySpan<byte> right, ReadOnlySpan<byte> left, ReadOnlySpan<byte> top, ReadOnlySpan<byte> down,
-			ReadOnlySpan<byte> back, ReadOnlySpan<byte> front, int width, int height, CancellationToken token)
+		private KtxFile EncodeCubeMapToKtxInternal(Memory<ColorRgba32> right, Memory<ColorRgba32> left, Memory<ColorRgba32> top, Memory<ColorRgba32> down,
+			Memory<ColorRgba32> back, Memory<ColorRgba32> front, int width, int height, Stream outputStream, CancellationToken token)
+		{
+			return EncodeCubeMapToKtxInternal(
+				right.AsMemory2D(width, height), left.AsMemory2D(width, height),
+				top.AsMemory2D(width, height), down.AsMemory2D(width, height),
+				back.AsMemory2D(width, height), front.AsMemory2D(width, height),
+				outputStream, token);
+		}
+
+		private KtxFile EncodeCubeMapToKtxInternal(Memory2D<ColorRgba32> right, Memory2D<ColorRgba32> left, Memory2D<ColorRgba32> top, Memory2D<ColorRgba32> down,
+			Memory2D<ColorRgba32> back, Memory2D<ColorRgba32> front, CancellationToken token)
 		{
 			KtxFile output;
 			IBcBlockEncoder compressedEncoder = null;
 			IRawEncoder uncompressedEncoder = null;
 
-			if (right.Length != width * height * 4)
-			{
-				throw new ArgumentException("The input pixels must be provided in 4 bytes per pixel rgba format.");
-			}
+			var faces = new[] { right, left, top, down, back, front };
 
-			if (right.Length != left.Length || right.Length != top.Length || right.Length != down.Length
-				|| right.Length != back.Length || right.Length != front.Length)
-			{
-				throw new ArgumentException("All input images of a cubemap should be the same size.");
-			}
-
-			var faces = new[] { right.ToArray(), left.ToArray(), top.ToArray(), down.ToArray(), back.ToArray(), front.ToArray() };
+			var width = right.Width;
+			var height = right.Height;
 
 			// Setup encoder
 			var isCompressedFormat = OutputOptions.Format.IsCompressedFormat();
@@ -947,7 +795,7 @@ namespace BCnEncoder.Encoder
 				}
 
 				output = new KtxFile(
-					KtxHeader.InitializeCompressed(width, height,
+					KtxHeader.InitializeCompressed(width,height,
 						compressedEncoder.GetInternalFormat(),
 						compressedEncoder.GetBaseInternalFormat()));
 			}
@@ -955,7 +803,7 @@ namespace BCnEncoder.Encoder
 			{
 				uncompressedEncoder = GetRawEncoder(OutputOptions.Format);
 				output = new KtxFile(
-					KtxHeader.InitializeUncompressed(width, height,
+					KtxHeader.InitializeUncompressed(width,height,
 						uncompressedEncoder.GetGlType(),
 						uncompressedEncoder.GetGlFormat(),
 						uncompressedEncoder.GetGlTypeSize(),
@@ -965,7 +813,7 @@ namespace BCnEncoder.Encoder
 			}
 
 			var numMipMaps = OutputOptions.GenerateMipMaps ? OutputOptions.MaxMipMapLevel : 1;
-			var mipLength = MipMapper.CalculateMipChainLength(width, height, numMipMaps);
+			var mipLength = MipMapper.CalculateMipChainLength(width,height, numMipMaps);
 			for (uint i = 0; i < mipLength; i++)
 			{
 				output.MipMaps.Add(new KtxMipmap(0, 0, 0, (uint)faces.Length));
@@ -984,7 +832,7 @@ namespace BCnEncoder.Encoder
 			{
 				for (var mip = 0; mip < numMipMaps; mip++)
 				{
-					MipMapper.CalculateMipLevelSize(width, height, mip, out var mipWidth, out var mipHeight);
+					MipMapper.CalculateMipLevelSize(width,height, mip, out var mipWidth, out var mipHeight);
 					totalBlocks += isCompressedFormat ? ImageToBlocks.CalculateNumOfBlocks(mipWidth, mipHeight) : mipWidth * mipHeight;
 				}
 			}
@@ -995,50 +843,42 @@ namespace BCnEncoder.Encoder
 			for (var face = 0; face < faces.Length; face++)
 			{
 				var mipChain = MipMapper.GenerateMipChain(faces[face], width, height, ref numMipMaps);
-				try
+
+				// Encode all mipmap levels per face
+				for (var mipLevel = 0; mipLevel < numMipMaps; mipLevel++)
 				{
-					// Encode all mipmap levels per face
-					for (var mip = 0; mip < numMipMaps; mip++)
+					byte[] encoded;
+					if (isCompressedFormat)
 					{
-						byte[] encoded;
-						if (isCompressedFormat)
-						{
-							var blocks = ImageToBlocks.ImageTo4X4(mipChain[mip].Frames[0], out var blocksWidth, out var blocksHeight);
-							encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
+						var blocks = ImageToBlocks.ImageTo4X4(mipChain[mipLevel], out var blocksWidth, out var blocksHeight);
+						encoded = compressedEncoder.Encode(blocks, blocksWidth, blocksHeight, OutputOptions.Quality, context);
 
-							processedBlocks += blocks.Length;
-							context.Progress.SetProcessedBlocks(processedBlocks);
-						}
-						else
-						{
-							if (!mipChain[mip].TryGetSinglePixelSpan(out var mipPixels))
-							{
-								throw new Exception("Cannot get pixel span.");
-							}
-
-							encoded = uncompressedEncoder.Encode(mipPixels);
-
-							processedBlocks += mipPixels.Length;
-							context.Progress.SetProcessedBlocks(processedBlocks);
-						}
-
-						if (face == 0)
-						{
-							output.MipMaps[mip] = new KtxMipmap((uint)encoded.Length,
-								(uint)mipChain[mip].Width,
-								(uint)mipChain[mip].Height, (uint)faces.Length);
-						}
-
-						output.MipMaps[mip].Faces[face] = new KtxMipFace(encoded,
-							(uint)mipChain[mip].Width,
-							(uint)mipChain[mip].Height);
+						processedBlocks += blocks.Length;
+						context.Progress.SetProcessedBlocks(processedBlocks);
 					}
-				}
-				finally
-				{
-					// Dispose all mipmap levels, even if operation was cancelled
-					foreach (var image in mipChain)
-						image.Dispose();
+					else
+					{
+						if (!mipChain[mipLevel].TryGetMemory(out var mipMemory))
+						{
+							throw new InvalidOperationException("Could not get Memory<T> from Memory2D<T>.");
+						}
+
+						encoded = uncompressedEncoder.Encode(mipMemory);
+
+						processedBlocks += mipMemory.Length;
+						context.Progress.SetProcessedBlocks(processedBlocks);
+					}
+
+					if (face == 0)
+					{
+						output.MipMaps[mipLevel] = new KtxMipmap((uint)encoded.Length,
+							(uint)mipChain[mipLevel].Width,
+							(uint)mipChain[mipLevel].Height, (uint)faces.Length);
+					}
+
+					output.MipMaps[mipLevel].Faces[face] = new KtxMipFace(encoded,
+						(uint)mipChain[mipLevel].Width,
+						(uint)mipChain[mipLevel].Height);
 				}
 			}
 
@@ -1061,7 +901,7 @@ namespace BCnEncoder.Encoder
 			}
 
 			if (right.Length != left.Length || right.Length != top.Length || right.Length != down.Length
-			    || right.Length != back.Length || right.Length != front.Length)
+				|| right.Length != back.Length || right.Length != front.Length)
 			{
 				throw new ArgumentException("All input images of a cubemap should be the same size.");
 			}

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -1325,10 +1325,10 @@ namespace BCnEncoder.Encoder
 					return new Bc3BlockEncoder();
 
 				case CompressionFormat.Bc4:
-					return new Bc4BlockEncoder(InputOptions.LuminanceAsRed);
+					return new Bc4BlockEncoder(InputOptions.Bc4Component);
 
 				case CompressionFormat.Bc5:
-					return new Bc5BlockEncoder();
+					return new Bc5BlockEncoder(InputOptions.Bc5Component1, InputOptions.Bc5Component2);
 
 				case CompressionFormat.Bc7:
 					return new Bc7Encoder();

--- a/BCnEnc.Net/Encoder/ColorChooser.cs
+++ b/BCnEnc.Net/Encoder/ColorChooser.cs
@@ -1,27 +1,26 @@
-﻿using System;
+using System;
 using BCnEncoder.Shared;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder
 {
 	internal static class ColorChooser
 	{
 
-		public static int ChooseClosestColor4(ReadOnlySpan<ColorRgb24> colors, Rgba32 color, float rWeight, float gWeight, float bWeight, out float error)
+		public static int ChooseClosestColor4(ReadOnlySpan<ColorRgb24> colors, ColorRgba32 color, float rWeight, float gWeight, float bWeight, out float error)
 		{
 			ReadOnlySpan<float> d = stackalloc float[4] {
-				MathF.Abs(colors[0].r - color.R) * rWeight
-				+ MathF.Abs(colors[0].g - color.G) * gWeight
-				+ MathF.Abs(colors[0].b - color.B) * bWeight,
-				MathF.Abs(colors[1].r - color.R) * rWeight
-				+ MathF.Abs(colors[1].g - color.G) * gWeight
-				+ MathF.Abs(colors[1].b - color.B) * bWeight,
-				MathF.Abs(colors[2].r - color.R) * rWeight
-				+ MathF.Abs(colors[2].g - color.G) * gWeight
-				+ MathF.Abs(colors[2].b - color.B) * bWeight,
-				MathF.Abs(colors[3].r - color.R) * rWeight
-				+ MathF.Abs(colors[3].g - color.G) * gWeight
-				+ MathF.Abs(colors[3].b - color.B) * bWeight,
+				MathF.Abs(colors[0].r - color.r) * rWeight
+				+ MathF.Abs(colors[0].g - color.g) * gWeight
+				+ MathF.Abs(colors[0].b - color.b) * bWeight,
+				MathF.Abs(colors[1].r - color.r) * rWeight
+				+ MathF.Abs(colors[1].g - color.g) * gWeight
+				+ MathF.Abs(colors[1].b - color.b) * bWeight,
+				MathF.Abs(colors[2].r - color.r) * rWeight
+				+ MathF.Abs(colors[2].g - color.g) * gWeight
+				+ MathF.Abs(colors[2].b - color.b) * bWeight,
+				MathF.Abs(colors[3].r - color.r) * rWeight
+				+ MathF.Abs(colors[3].g - color.g) * gWeight
+				+ MathF.Abs(colors[3].b - color.b) * bWeight,
 			};
 
 			var b0 = d[0] > d[3] ? 1 : 0;
@@ -40,30 +39,30 @@ namespace BCnEncoder.Encoder
 		}
 
 
-		public static int ChooseClosestColor4AlphaCutoff(ReadOnlySpan<ColorRgb24> colors, Rgba32 color, float rWeight, float gWeight, float bWeight, int alphaCutoff, bool hasAlpha, out float error)
+		public static int ChooseClosestColor4AlphaCutoff(ReadOnlySpan<ColorRgb24> colors, ColorRgba32 color, float rWeight, float gWeight, float bWeight, int alphaCutoff, bool hasAlpha, out float error)
 		{
 
-			if (hasAlpha && color.A < alphaCutoff)
+			if (hasAlpha && color.a < alphaCutoff)
 			{
 				error = 0;
 				return 3;
 			}
 
 			ReadOnlySpan<float> d = stackalloc float[4] {
-				MathF.Abs(colors[0].r - color.R) * rWeight
-				+ MathF.Abs(colors[0].g - color.G) * gWeight
-				+ MathF.Abs(colors[0].b - color.B) * bWeight,
-				MathF.Abs(colors[1].r - color.R) * rWeight
-				+ MathF.Abs(colors[1].g - color.G) * gWeight
-				+ MathF.Abs(colors[1].b - color.B) * bWeight,
-				MathF.Abs(colors[2].r - color.R) * rWeight
-				+ MathF.Abs(colors[2].g - color.G) * gWeight
-				+ MathF.Abs(colors[2].b - color.B) * bWeight,
+				MathF.Abs(colors[0].r - color.r) * rWeight
+				+ MathF.Abs(colors[0].g - color.g) * gWeight
+				+ MathF.Abs(colors[0].b - color.b) * bWeight,
+				MathF.Abs(colors[1].r - color.r) * rWeight
+				+ MathF.Abs(colors[1].g - color.g) * gWeight
+				+ MathF.Abs(colors[1].b - color.b) * bWeight,
+				MathF.Abs(colors[2].r - color.r) * rWeight
+				+ MathF.Abs(colors[2].g - color.g) * gWeight
+				+ MathF.Abs(colors[2].b - color.b) * bWeight,
 
 				hasAlpha ? 999 :
-				MathF.Abs(colors[3].r - color.R) * rWeight
-				+ MathF.Abs(colors[3].g - color.G) * gWeight
-				+ MathF.Abs(colors[3].b - color.B) * bWeight,
+				MathF.Abs(colors[3].r - color.r) * rWeight
+				+ MathF.Abs(colors[3].g - color.g) * gWeight
+				+ MathF.Abs(colors[3].b - color.b) * bWeight,
 			};
 
 			var b0 = d[0] > d[2] ? 1 : 0;
@@ -80,20 +79,20 @@ namespace BCnEncoder.Encoder
 			return idx;
 		}
 
-		public static int ChooseClosestColor(Span<ColorRgb24> colors, Rgba32 color)
+		public static int ChooseClosestColor(Span<ColorRgb24> colors, ColorRgba32 color)
 		{
 			var closest = 0;
 			var closestError =
-				Math.Abs(colors[0].r - color.R)
-				+ Math.Abs(colors[0].g - color.G)
-				+ Math.Abs(colors[0].b - color.B);
+				Math.Abs(colors[0].r - color.r)
+				+ Math.Abs(colors[0].g - color.g)
+				+ Math.Abs(colors[0].b - color.b);
 
 			for (var i = 1; i < colors.Length; i++)
 			{
 				var error =
-					Math.Abs(colors[i].r - color.R)
-					+ Math.Abs(colors[i].g - color.G)
-					+ Math.Abs(colors[i].b - color.B);
+					Math.Abs(colors[i].r - color.r)
+					+ Math.Abs(colors[i].g - color.g)
+					+ Math.Abs(colors[i].b - color.b);
 				if (error < closestError)
 				{
 					closest = i;
@@ -103,22 +102,22 @@ namespace BCnEncoder.Encoder
 			return closest;
 		}
 
-		public static int ChooseClosestColor(Span<ColorRgba32> colors, Rgba32 color)
+		public static int ChooseClosestColor(Span<ColorRgba32> colors, ColorRgba32 color)
 		{
 			var closest = 0;
 			var closestError =
-				Math.Abs(colors[0].r - color.R)
-				+ Math.Abs(colors[0].g - color.G)
-				+ Math.Abs(colors[0].b - color.B)
-				+ Math.Abs(colors[0].a - color.A);
+				Math.Abs(colors[0].r - color.r)
+				+ Math.Abs(colors[0].g - color.g)
+				+ Math.Abs(colors[0].b - color.b)
+				+ Math.Abs(colors[0].a - color.a);
 
 			for (var i = 1; i < colors.Length; i++)
 			{
 				var error =
-					Math.Abs(colors[i].r - color.R)
-					+ Math.Abs(colors[i].g - color.G)
-					+ Math.Abs(colors[i].b - color.B)
-					+ Math.Abs(colors[i].a - color.A);
+					Math.Abs(colors[i].r - color.r)
+					+ Math.Abs(colors[i].g - color.g)
+					+ Math.Abs(colors[i].b - color.b)
+					+ Math.Abs(colors[i].a - color.a);
 				if (error < closestError)
 				{
 					closest = i;
@@ -128,26 +127,26 @@ namespace BCnEncoder.Encoder
 			return closest;
 		}
 
-		public static int ChooseClosestColorAlphaCutOff(Span<ColorRgba32> colors, Rgba32 color, byte alphaCutOff = 255 / 2)
+		public static int ChooseClosestColorAlphaCutOff(Span<ColorRgba32> colors, ColorRgba32 color, byte alphaCutOff = 255 / 2)
 		{
-			if (color.A <= alphaCutOff)
+			if (color.a <= alphaCutOff)
 			{
 				return 3;
 			}
 
 			var closest = 0;
 			var closestError =
-				Math.Abs(colors[0].r - color.R)
-				+ Math.Abs(colors[0].g - color.G)
-				+ Math.Abs(colors[0].b - color.B);
+				Math.Abs(colors[0].r - color.r)
+				+ Math.Abs(colors[0].g - color.g)
+				+ Math.Abs(colors[0].b - color.b);
 
 			for (var i = 1; i < colors.Length; i++)
 			{
 				if (i == 3) continue; // Skip transparent
 				var error =
-					Math.Abs(colors[i].r - color.R)
-					+ Math.Abs(colors[i].g - color.G)
-					+ Math.Abs(colors[i].b - color.B);
+					Math.Abs(colors[i].r - color.r)
+					+ Math.Abs(colors[i].g - color.g)
+					+ Math.Abs(colors[i].b - color.b);
 				if (error < closestError)
 				{
 					closest = i;
@@ -182,7 +181,7 @@ namespace BCnEncoder.Encoder
 			return closest;
 		}
 
-		public static int ChooseClosestColor(Span<ColorYCbCr> colors, Rgba32 color, float luminanceMultiplier = 4)
+		public static int ChooseClosestColor(Span<ColorYCbCr> colors, ColorRgba32 color, float luminanceMultiplier = 4)
 			=> ChooseClosestColor(colors, new ColorYCbCr(color), luminanceMultiplier);
 	}
 }

--- a/BCnEnc.Net/Encoder/IBcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/IBcBlockEncoder.cs
@@ -1,4 +1,5 @@
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Encoder/IBcBlockEncoder.cs
+++ b/BCnEnc.Net/Encoder/IBcBlockEncoder.cs
@@ -1,3 +1,4 @@
+using System;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
 
@@ -6,9 +7,11 @@ namespace BCnEncoder.Encoder
 	internal interface IBcBlockEncoder
 	{
 		byte[] Encode(RawBlock4X4Rgba32[] blocks, int blockWidth, int blockHeight, CompressionQuality quality, OperationContext context);
+		void EncodeBlock(RawBlock4X4Rgba32 block, CompressionQuality quality, Span<byte> output);
 		GlInternalFormat GetInternalFormat();
 		GlFormat GetBaseInternalFormat();
 		DxgiFormat GetDxgiFormat();
+		int GetBlockSize();
 	}
 
 

--- a/BCnEnc.Net/Encoder/Options/EncoderInputOptions.cs
+++ b/BCnEnc.Net/Encoder/Options/EncoderInputOptions.cs
@@ -1,14 +1,31 @@
-﻿namespace BCnEncoder.Encoder.Options
+using BCnEncoder.Shared;
+
+namespace BCnEncoder.Encoder.Options
 {
     /// <summary>
     /// The input options for the decoder.
     /// </summary>
 	public class EncoderInputOptions
     {
+	    /// <summary>
+	    /// If true, when encoding to a Format that only includes a red channel,
+	    /// use the pixel luminance instead of just the red channel. Default is false.
+	    /// </summary>
+	    public bool LuminanceAsRed { get; set; } = false;
+
+		/// <summary>
+		/// The color channel to populate with the values of a BC4 block.
+		/// </summary>
+		public Bc4Component Bc4Component { get; } = Bc4Component.R;
+
         /// <summary>
-        /// If true, when encoding to a Format that only includes a red channel,
-        /// use the pixel luminance instead of just the red channel. Default is false.
+        /// The color channel to populate with the values of the first BC5 block.
         /// </summary>
-        public bool LuminanceAsRed { get; set; } = false;
-    }
+        public Bc4Component Bc5Component1 { get; } = Bc4Component.R;
+
+        /// <summary>
+        /// The color channel to populate with the values of the second BC5 block.
+        /// </summary>
+        public Bc4Component Bc5Component2 { get; } = Bc4Component.G;
+	}
 }

--- a/BCnEnc.Net/Encoder/Options/EncoderInputOptions.cs
+++ b/BCnEnc.Net/Encoder/Options/EncoderInputOptions.cs
@@ -8,24 +8,24 @@ namespace BCnEncoder.Encoder.Options
 	public class EncoderInputOptions
     {
 	    /// <summary>
-	    /// If true, when encoding to a Format that only includes a red channel,
-	    /// use the pixel luminance instead of just the red channel. Default is false.
+	    /// If true, when encoding to R8 raw format,
+	    /// use the pixel luminance instead of just the red channel. Default is false. (Does not apply to BC4 format)
 	    /// </summary>
 	    public bool LuminanceAsRed { get; set; } = false;
 
+	    /// <summary>
+	    /// The color channel to take for the values of a BC4 block.
+	    /// </summary>
+		public Bc4Component Bc4Component { get; set; } = Bc4Component.R;
+
 		/// <summary>
-		/// The color channel to populate with the values of a BC4 block.
+		/// The color channel to take for the values of the first BC5 block.
 		/// </summary>
-		public Bc4Component Bc4Component { get; } = Bc4Component.R;
+		public Bc4Component Bc5Component1 { get; set; } = Bc4Component.R;
 
-        /// <summary>
-        /// The color channel to populate with the values of the first BC5 block.
-        /// </summary>
-        public Bc4Component Bc5Component1 { get; } = Bc4Component.R;
-
-        /// <summary>
-        /// The color channel to populate with the values of the second BC5 block.
-        /// </summary>
-        public Bc4Component Bc5Component2 { get; } = Bc4Component.G;
+		/// <summary>
+		/// The color channel to take for the values of the second BC5 block.
+		/// </summary>
+		public Bc4Component Bc5Component2 { get; set; } = Bc4Component.G;
 	}
 }

--- a/BCnEnc.Net/Encoder/Options/EncoderOutputOptions.cs
+++ b/BCnEnc.Net/Encoder/Options/EncoderOutputOptions.cs
@@ -1,4 +1,4 @@
-﻿using BCnEncoder.Shared;
+using BCnEncoder.Shared;
 
 namespace BCnEncoder.Encoder.Options
 {
@@ -44,5 +44,11 @@ namespace BCnEncoder.Encoder.Options
         /// Default is false.
         /// </summary>
         public bool DdsBc1WriteAlphaFlag { get; set; } = false;
-    }
+
+		/// <summary>
+		/// When writing a dds file, always prefer using the Dxt10 header
+		/// to write the compression format instead of DwFourCC.
+		/// </summary>
+		public bool DdsPreferDxt10Header { get; set; } = false;
+	}
 }

--- a/BCnEnc.Net/Encoder/Options/EncoderOutputOptions.cs
+++ b/BCnEnc.Net/Encoder/Options/EncoderOutputOptions.cs
@@ -50,20 +50,5 @@ namespace BCnEncoder.Encoder.Options
 		/// to write the compression format instead of DwFourCC.
 		/// </summary>
 		public bool DdsPreferDxt10Header { get; set; } = false;
-
-		/// <summary>
-		/// The color channel to take for the values of a BC4 block.
-		/// </summary>
-		public Bc4Component Bc4Component { get; } = Bc4Component.R;
-
-		/// <summary>
-		/// The color channel to take for the values of the first BC5 block.
-		/// </summary>
-		public Bc4Component Bc5Component1 { get; } = Bc4Component.R;
-
-		/// <summary>
-		/// The color channel to take for the values of the second BC5 block.
-		/// </summary>
-		public Bc4Component Bc5Component2 { get; } = Bc4Component.G;
-	}
+    }
 }

--- a/BCnEnc.Net/Encoder/Options/EncoderOutputOptions.cs
+++ b/BCnEnc.Net/Encoder/Options/EncoderOutputOptions.cs
@@ -50,5 +50,20 @@ namespace BCnEncoder.Encoder.Options
 		/// to write the compression format instead of DwFourCC.
 		/// </summary>
 		public bool DdsPreferDxt10Header { get; set; } = false;
+
+		/// <summary>
+		/// The color channel to take for the values of a BC4 block.
+		/// </summary>
+		public Bc4Component Bc4Component { get; } = Bc4Component.R;
+
+		/// <summary>
+		/// The color channel to take for the values of the first BC5 block.
+		/// </summary>
+		public Bc4Component Bc5Component1 { get; } = Bc4Component.R;
+
+		/// <summary>
+		/// The color channel to take for the values of the second BC5 block.
+		/// </summary>
+		public Bc4Component Bc5Component2 { get; } = Bc4Component.G;
 	}
 }

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -6,7 +6,7 @@ namespace BCnEncoder.Encoder
 {
 	internal interface IRawEncoder
 	{
-		byte[] Encode(Memory<ColorRgba32> pixels);
+		byte[] Encode(ReadOnlyMemory<ColorRgba32> pixels);
 		GlInternalFormat GetInternalFormat();
 		GlFormat GetBaseInternalFormat();
 		GlFormat GetGlFormat();
@@ -24,7 +24,7 @@ namespace BCnEncoder.Encoder
 			this.useLuminance = useLuminance;
 		}
 
-		public byte[] Encode(Memory<ColorRgba32> pixels)
+		public byte[] Encode(ReadOnlyMemory<ColorRgba32> pixels)
 		{
 			var span = pixels.Span;
 
@@ -77,7 +77,7 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgEncoder : IRawEncoder
 	{
-		public byte[] Encode(Memory<ColorRgba32> pixels)
+		public byte[] Encode(ReadOnlyMemory<ColorRgba32> pixels)
 		{
 			var span = pixels.Span;
 
@@ -123,7 +123,7 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgbEncoder : IRawEncoder
 	{
-		public byte[] Encode(Memory<ColorRgba32> pixels)
+		public byte[] Encode(ReadOnlyMemory<ColorRgba32> pixels)
 		{
 			var span = pixels.Span;
 
@@ -170,7 +170,7 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgbaEncoder : IRawEncoder
 	{
-		public byte[] Encode(Memory<ColorRgba32> pixels)
+		public byte[] Encode(ReadOnlyMemory<ColorRgba32> pixels)
 		{
 			var span = pixels.Span;
 
@@ -218,7 +218,7 @@ namespace BCnEncoder.Encoder
 
 	internal class RawBgraEncoder : IRawEncoder
 	{
-		public byte[] Encode(Memory<ColorRgba32> pixels)
+		public byte[] Encode(ReadOnlyMemory<ColorRgba32> pixels)
 		{
 			var span = pixels.Span;
 

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -1,13 +1,12 @@
 using System;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder
 {
 	internal interface IRawEncoder
 	{
-		byte[] Encode(ReadOnlySpan<Rgba32> pixels);
+		byte[] Encode(Memory<ColorRgba32> pixels);
 		GlInternalFormat GetInternalFormat();
 		GlFormat GetBaseInternalFormat();
 		GlFormat GetGlFormat();
@@ -25,18 +24,20 @@ namespace BCnEncoder.Encoder
 			this.useLuminance = useLuminance;
 		}
 
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length];
 			for (var i = 0; i < pixels.Length; i++)
 			{
 				if (useLuminance)
 				{
-					output[i] = (byte)(new ColorYCbCr(pixels[i]).y * 255);
+					output[i] = (byte)(new ColorYCbCr(span[i]).y * 255);
 				}
 				else
 				{
-					output[i] = pixels[i].R;
+					output[i] = span[i].R;
 				}
 
 			}
@@ -76,13 +77,15 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 2];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 2] = pixels[i].R;
-				output[i * 2 + 1] = pixels[i].G;
+				output[i * 2] = span[i].R;
+				output[i * 2 + 1] = span[i].G;
 			}
 			return output;
 		}
@@ -120,14 +123,16 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgbEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 3];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 3] = pixels[i].R;
-				output[i * 3 + 1] = pixels[i].G;
-				output[i * 3 + 2] = pixels[i].B;
+				output[i * 3] = span[i].R;
+				output[i * 3 + 1] = span[i].G;
+				output[i * 3 + 2] = span[i].B;
 			}
 			return output;
 		}
@@ -165,15 +170,17 @@ namespace BCnEncoder.Encoder
 
 	internal class RawRgbaEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = pixels[i].R;
-				output[i * 4 + 1] = pixels[i].G;
-				output[i * 4 + 2] = pixels[i].B;
-				output[i * 4 + 3] = pixels[i].A;
+				output[i * 4] = span[i].R;
+				output[i * 4 + 1] = span[i].G;
+				output[i * 4 + 2] = span[i].B;
+				output[i * 4 + 3] = span[i].A;
 			}
 			return output;
 		}
@@ -211,15 +218,17 @@ namespace BCnEncoder.Encoder
 
 	internal class RawBgraEncoder : IRawEncoder
 	{
-		public byte[] Encode(ReadOnlySpan<Rgba32> pixels)
+		public byte[] Encode(Memory<ColorRgba32> pixels)
 		{
+			var span = pixels.Span;
+
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = pixels[i].B;
-				output[i * 4 + 1] = pixels[i].G;
-				output[i * 4 + 2] = pixels[i].R;
-				output[i * 4 + 3] = pixels[i].A;
+				output[i * 4] = span[i].B;
+				output[i * 4 + 1] = span[i].G;
+				output[i * 4 + 2] = span[i].R;
+				output[i * 4 + 3] = span[i].A;
 			}
 			return output;
 		}

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -37,7 +37,7 @@ namespace BCnEncoder.Encoder
 				}
 				else
 				{
-					output[i] = span[i].R;
+					output[i] = span[i].r;
 				}
 
 			}
@@ -84,8 +84,8 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 2];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 2] = span[i].R;
-				output[i * 2 + 1] = span[i].G;
+				output[i * 2] = span[i].r;
+				output[i * 2 + 1] = span[i].g;
 			}
 			return output;
 		}
@@ -130,9 +130,9 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 3];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 3] = span[i].R;
-				output[i * 3 + 1] = span[i].G;
-				output[i * 3 + 2] = span[i].B;
+				output[i * 3] = span[i].r;
+				output[i * 3 + 1] = span[i].g;
+				output[i * 3 + 2] = span[i].b;
 			}
 			return output;
 		}
@@ -177,10 +177,10 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = span[i].R;
-				output[i * 4 + 1] = span[i].G;
-				output[i * 4 + 2] = span[i].B;
-				output[i * 4 + 3] = span[i].A;
+				output[i * 4] = span[i].r;
+				output[i * 4 + 1] = span[i].g;
+				output[i * 4 + 2] = span[i].b;
+				output[i * 4 + 3] = span[i].a;
 			}
 			return output;
 		}
@@ -225,10 +225,10 @@ namespace BCnEncoder.Encoder
 			var output = new byte[pixels.Length * 4];
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				output[i * 4] = span[i].B;
-				output[i * 4 + 1] = span[i].G;
-				output[i * 4 + 2] = span[i].R;
-				output[i * 4 + 3] = span[i].A;
+				output[i * 4] = span[i].b;
+				output[i * 4 + 1] = span[i].g;
+				output[i * 4 + 2] = span[i].r;
+				output[i * 4 + 3] = span[i].a;
 			}
 			return output;
 		}

--- a/BCnEnc.Net/Encoder/RawEncoders.cs
+++ b/BCnEnc.Net/Encoder/RawEncoders.cs
@@ -1,5 +1,6 @@
 using System;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Encoder

--- a/BCnEnc.Net/Shared/Bc4Component.cs
+++ b/BCnEnc.Net/Shared/Bc4Component.cs
@@ -1,0 +1,33 @@
+namespace BCnEncoder.Shared
+{
+	/// <summary>
+	/// The component to take from colors for BC4 and BC5.
+	/// </summary>
+	public enum Bc4Component
+	{
+		/// <summary>
+		/// Specifies the red component.
+		/// </summary>
+		R,
+
+		/// <summary>
+		/// Specifies the green component.
+		/// </summary>
+		G,
+
+		/// <summary>
+		/// Specifies the blue component.
+		/// </summary>
+		B,
+
+		/// <summary>
+		/// Specifies the alpha component.
+		/// </summary>
+		A,
+
+		/// <summary>
+		/// Specifies the luminance.
+		/// </summary>
+		Luminance
+	}
+}

--- a/BCnEnc.Net/Shared/Bc7Block.cs
+++ b/BCnEnc.Net/Shared/Bc7Block.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -826,7 +826,7 @@ namespace BCnEncoder.Shared
 					outputColor = SwapChannels(outputColor, rotation);
 				}
 
-				pixels[i] = outputColor.ToRgba32();
+				pixels[i] = outputColor;
 			}
 
 			return output;

--- a/BCnEnc.Net/Shared/Colors.cs
+++ b/BCnEnc.Net/Shared/Colors.cs
@@ -163,7 +163,7 @@ namespace BCnEncoder.Shared
 			);
 		}
 
-		public static implicit operator ColorRgba32(ColorRgb24 d) => new ColorRgba32(d.r, d.g, d.b, 255);
+		//public static implicit operator ColorRgba32(ColorRgb24 d) => new ColorRgba32(d.r, d.g, d.b, 255);
 
 		public override string ToString()
 		{
@@ -184,7 +184,7 @@ namespace BCnEncoder.Shared
 			this.cr = cr;
 		}
 
-		public ColorYCbCr(ColorRgb24 rgb)
+		internal ColorYCbCr(ColorRgb24 rgb)
 		{
 			var fr = (float)rgb.r / 255;
 			var fg = (float)rgb.g / 255;
@@ -195,7 +195,7 @@ namespace BCnEncoder.Shared
 			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
 		}
 
-		public ColorYCbCr(ColorRgb565 rgb)
+		internal ColorYCbCr(ColorRgb565 rgb)
 		{
 			var fr = (float)rgb.R / 255;
 			var fg = (float)rgb.G / 255;
@@ -228,7 +228,7 @@ namespace BCnEncoder.Shared
 			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
 		}
 
-		public ColorRgb565 ToColorRgb565()
+		internal ColorRgb565 ToColorRgb565()
 		{
 			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
 			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
@@ -445,7 +445,7 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	public struct ColorRgb565 : IEquatable<ColorRgb565>
+	internal struct ColorRgb565 : IEquatable<ColorRgb565>
 	{
 		public bool Equals(ColorRgb565 other)
 		{
@@ -601,7 +601,7 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	public struct ColorRgb24 : IEquatable<ColorRgb24>
+	internal struct ColorRgb24 : IEquatable<ColorRgb24>
 	{
 		public byte r, g, b;
 

--- a/BCnEnc.Net/Shared/Colors.cs
+++ b/BCnEnc.Net/Shared/Colors.cs
@@ -4,6 +4,305 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
+	public struct ColorRgba32 : IEquatable<ColorRgba32>
+	{
+		public byte r, g, b, a;
+		public ColorRgba32(byte r, byte g, byte b, byte a)
+		{
+			this.r = r;
+			this.g = g;
+			this.b = b;
+			this.a = a;
+		}
+
+		public ColorRgba32(Rgba32 color)
+		{
+			this.r = color.R;
+			this.g = color.G;
+			this.b = color.B;
+			this.a = color.A;
+		}
+
+		public bool Equals(ColorRgba32 other)
+		{
+			return r == other.r && g == other.g && b == other.b && a == other.a;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is ColorRgba32 other && Equals(other);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				var hashCode = r.GetHashCode();
+				hashCode = (hashCode * 397) ^ g.GetHashCode();
+				hashCode = (hashCode * 397) ^ b.GetHashCode();
+				hashCode = (hashCode * 397) ^ a.GetHashCode();
+				return hashCode;
+			}
+		}
+
+		public static bool operator ==(ColorRgba32 left, ColorRgba32 right)
+		{
+			return left.Equals(right);
+		}
+
+		public static bool operator !=(ColorRgba32 left, ColorRgba32 right)
+		{
+			return !left.Equals(right);
+		}
+
+		public static ColorRgba32 operator +(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r + right.r),
+				ByteHelper.ClampToByte(left.g + right.g),
+				ByteHelper.ClampToByte(left.b + right.b),
+				ByteHelper.ClampToByte(left.a + right.a));
+		}
+
+		public static ColorRgba32 operator -(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r - right.r),
+				ByteHelper.ClampToByte(left.g - right.g),
+				ByteHelper.ClampToByte(left.b - right.b),
+				ByteHelper.ClampToByte(left.a - right.a));
+		}
+
+		public static ColorRgba32 operator /(ColorRgba32 left, double right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte((int)(left.r / right)),
+				ByteHelper.ClampToByte((int)(left.g / right)),
+				ByteHelper.ClampToByte((int)(left.b / right)),
+				ByteHelper.ClampToByte((int)(left.a / right))
+			);
+		}
+
+		public static ColorRgba32 operator *(ColorRgba32 left, double right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte((int)(left.r * right)),
+				ByteHelper.ClampToByte((int)(left.g * right)),
+				ByteHelper.ClampToByte((int)(left.b * right)),
+				ByteHelper.ClampToByte((int)(left.a * right))
+			);
+		}
+
+		/// <summary>
+		/// Component-wise left shift
+		/// </summary>
+		public static ColorRgba32 operator <<(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r << right),
+				ByteHelper.ClampToByte(left.g << right),
+				ByteHelper.ClampToByte(left.b << right),
+				ByteHelper.ClampToByte(left.a << right)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise right shift
+		/// </summary>
+		public static ColorRgba32 operator >>(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r >> right),
+				ByteHelper.ClampToByte(left.g >> right),
+				ByteHelper.ClampToByte(left.b >> right),
+				ByteHelper.ClampToByte(left.a >> right)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise OR operation
+		/// </summary>
+		public static ColorRgba32 operator |(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r | right.r),
+				ByteHelper.ClampToByte(left.g | right.g),
+				ByteHelper.ClampToByte(left.b | right.b),
+				ByteHelper.ClampToByte(left.a | right.a)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise OR operation
+		/// </summary>
+		public static ColorRgba32 operator |(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r | right),
+				ByteHelper.ClampToByte(left.g | right),
+				ByteHelper.ClampToByte(left.b | right),
+				ByteHelper.ClampToByte(left.a | right)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise AND operation
+		/// </summary>
+		public static ColorRgba32 operator &(ColorRgba32 left, ColorRgba32 right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r & right.r),
+				ByteHelper.ClampToByte(left.g & right.g),
+				ByteHelper.ClampToByte(left.b & right.b),
+				ByteHelper.ClampToByte(left.a & right.a)
+			);
+		}
+
+		/// <summary>
+		/// Component-wise bitwise AND operation
+		/// </summary>
+		public static ColorRgba32 operator &(ColorRgba32 left, int right)
+		{
+			return new ColorRgba32(
+				ByteHelper.ClampToByte(left.r & right),
+				ByteHelper.ClampToByte(left.g & right),
+				ByteHelper.ClampToByte(left.b & right),
+				ByteHelper.ClampToByte(left.a & right)
+			);
+		}
+
+		public override string ToString()
+		{
+			return $"r : {r} g : {g} b : {b} a : {a}";
+		}
+
+		public Rgba32 ToRgba32()
+		{
+			return new Rgba32(r, g, b, a);
+		}
+	}
+
+	public struct ColorYCbCr
+	{
+		public float y;
+		public float cb;
+		public float cr;
+
+		public ColorYCbCr(float y, float cb, float cr)
+		{
+			this.y = y;
+			this.cb = cb;
+			this.cr = cr;
+		}
+
+		public ColorYCbCr(ColorRgb24 rgb)
+		{
+			var fr = (float)rgb.r / 255;
+			var fg = (float)rgb.g / 255;
+			var fb = (float)rgb.b / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(ColorRgb565 rgb)
+		{
+			var fr = (float)rgb.R / 255;
+			var fg = (float)rgb.G / 255;
+			var fb = (float)rgb.B / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(ColorRgba32 rgba)
+		{
+			var fr = (float)rgba.r / 255;
+			var fg = (float)rgba.g / 255;
+			var fb = (float)rgba.b / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(Rgba32 rgb)
+		{
+			var fr = (float)rgb.R / 255;
+			var fg = (float)rgb.G / 255;
+			var fb = (float)rgb.B / 255;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorYCbCr(Vector3 vec)
+		{
+			var fr = (float)vec.X;
+			var fg = (float)vec.Y;
+			var fb = (float)vec.Z;
+
+			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
+			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
+			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
+		}
+
+		public ColorRgb565 ToColorRgb565()
+		{
+			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
+			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
+			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
+
+			return new ColorRgb565((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+		}
+
+		public override string ToString()
+		{
+			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
+			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
+			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
+
+			return $"r : {r * 255} g : {g * 255} b : {b * 255}";
+		}
+
+		public float CalcDistWeighted(ColorYCbCr other, float yWeight = 4)
+		{
+			var dy = (y - other.y) * (y - other.y) * yWeight;
+			var dcb = (cb - other.cb) * (cb - other.cb);
+			var dcr = (cr - other.cr) * (cr - other.cr);
+
+			return MathF.Sqrt(dy + dcb + dcr);
+		}
+
+		public static ColorYCbCr operator +(ColorYCbCr left, ColorYCbCr right)
+		{
+			return new ColorYCbCr(
+				left.y + right.y,
+				left.cb + right.cb,
+				left.cr + right.cr);
+		}
+
+		public static ColorYCbCr operator /(ColorYCbCr left, float right)
+		{
+			return new ColorYCbCr(
+				left.y / right,
+				left.cb / right,
+				left.cr / right);
+		}
+
+		public Rgba32 ToRgba32()
+		{
+			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
+			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
+			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
+
+			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), 255);
+		}
+	}
+
 	internal struct ColorRgb555 : IEquatable<ColorRgb555>
 	{
 		public bool Equals(ColorRgb555 other)
@@ -314,182 +613,6 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	internal struct ColorRgba32 : IEquatable<ColorRgba32>
-	{
-		public byte r, g, b, a;
-		public ColorRgba32(byte r, byte g, byte b, byte a)
-		{
-			this.r = r;
-			this.g = g;
-			this.b = b;
-			this.a = a;
-		}
-
-		public ColorRgba32(Rgba32 color)
-		{
-			this.r = color.R;
-			this.g = color.G;
-			this.b = color.B;
-			this.a = color.A;
-		}
-
-		public bool Equals(ColorRgba32 other)
-		{
-			return r == other.r && g == other.g && b == other.b && a == other.a;
-		}
-
-		public override bool Equals(object obj)
-		{
-			return obj is ColorRgba32 other && Equals(other);
-		}
-
-		public override int GetHashCode()
-		{
-			unchecked
-			{
-				var hashCode = r.GetHashCode();
-				hashCode = (hashCode * 397) ^ g.GetHashCode();
-				hashCode = (hashCode * 397) ^ b.GetHashCode();
-				hashCode = (hashCode * 397) ^ a.GetHashCode();
-				return hashCode;
-			}
-		}
-
-		public static bool operator ==(ColorRgba32 left, ColorRgba32 right)
-		{
-			return left.Equals(right);
-		}
-
-		public static bool operator !=(ColorRgba32 left, ColorRgba32 right)
-		{
-			return !left.Equals(right);
-		}
-
-		public static ColorRgba32 operator +(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r + right.r),
-				ByteHelper.ClampToByte(left.g + right.g),
-				ByteHelper.ClampToByte(left.b + right.b),
-				ByteHelper.ClampToByte(left.a + right.a));
-		}
-
-		public static ColorRgba32 operator -(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r - right.r),
-				ByteHelper.ClampToByte(left.g - right.g),
-				ByteHelper.ClampToByte(left.b - right.b),
-				ByteHelper.ClampToByte(left.a - right.a));
-		}
-
-		public static ColorRgba32 operator /(ColorRgba32 left, double right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte((int)(left.r / right)),
-				ByteHelper.ClampToByte((int)(left.g / right)),
-				ByteHelper.ClampToByte((int)(left.b / right)),
-				ByteHelper.ClampToByte((int)(left.a / right))
-			);
-		}
-
-		public static ColorRgba32 operator *(ColorRgba32 left, double right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte((int)(left.r * right)),
-				ByteHelper.ClampToByte((int)(left.g * right)),
-				ByteHelper.ClampToByte((int)(left.b * right)),
-				ByteHelper.ClampToByte((int)(left.a * right))
-			);
-		}
-
-		/// <summary>
-		/// Component-wise left shift
-		/// </summary>
-		public static ColorRgba32 operator <<(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r << right),
-				ByteHelper.ClampToByte(left.g << right),
-				ByteHelper.ClampToByte(left.b << right),
-				ByteHelper.ClampToByte(left.a << right)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise right shift
-		/// </summary>
-		public static ColorRgba32 operator >>(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r >> right),
-				ByteHelper.ClampToByte(left.g >> right),
-				ByteHelper.ClampToByte(left.b >> right),
-				ByteHelper.ClampToByte(left.a >> right)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise OR operation
-		/// </summary>
-		public static ColorRgba32 operator |(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r | right.r),
-				ByteHelper.ClampToByte(left.g | right.g),
-				ByteHelper.ClampToByte(left.b | right.b),
-				ByteHelper.ClampToByte(left.a | right.a)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise OR operation
-		/// </summary>
-		public static ColorRgba32 operator |(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r | right),
-				ByteHelper.ClampToByte(left.g | right),
-				ByteHelper.ClampToByte(left.b | right),
-				ByteHelper.ClampToByte(left.a | right)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise AND operation
-		/// </summary>
-		public static ColorRgba32 operator &(ColorRgba32 left, ColorRgba32 right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r & right.r),
-				ByteHelper.ClampToByte(left.g & right.g),
-				ByteHelper.ClampToByte(left.b & right.b),
-				ByteHelper.ClampToByte(left.a & right.a)
-			);
-		}
-
-		/// <summary>
-		/// Component-wise bitwise AND operation
-		/// </summary>
-		public static ColorRgba32 operator &(ColorRgba32 left, int right)
-		{
-			return new ColorRgba32(
-				ByteHelper.ClampToByte(left.r & right),
-				ByteHelper.ClampToByte(left.g & right),
-				ByteHelper.ClampToByte(left.b & right),
-				ByteHelper.ClampToByte(left.a & right)
-			);
-		}
-
-		public override string ToString() {
-			return $"r : {r} g : {g} b : {b} a : {a}";
-		}
-
-		public Rgba32 ToRgba32() {
-			return new Rgba32(r, g, b, a);
-		}
-	}
-
 	internal struct ColorRgb24 : IEquatable<ColorRgb24>
 	{
 		public byte r, g, b;
@@ -585,122 +708,6 @@ namespace BCnEncoder.Shared
 
 		public override string ToString() {
 			return $"r : {r} g : {g} b : {b}";
-		}
-	}
-
-	internal struct ColorYCbCr
-	{
-		public float y;
-		public float cb;
-		public float cr;
-
-		public ColorYCbCr(float y, float cb, float cr)
-		{
-			this.y = y;
-			this.cb = cb;
-			this.cr = cr;
-		}
-
-		public ColorYCbCr(ColorRgb24 rgb)
-		{
-			var fr = (float)rgb.r / 255;
-			var fg = (float)rgb.g / 255;
-			var fb = (float)rgb.b / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(ColorRgb565 rgb)
-		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(ColorRgba32 rgba)
-		{
-			var fr = (float)rgba.r / 255;
-			var fg = (float)rgba.g / 255;
-			var fb = (float)rgba.b / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(Rgba32 rgb)
-		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(Vector3 vec) {
-			var fr = (float) vec.X;
-			var fg = (float) vec.Y;
-			var fb = (float) vec.Z;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorRgb565 ToColorRgb565() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new ColorRgb565((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
-		}
-
-		public override string ToString() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return $"r : {r * 255} g : {g * 255} b : {b * 255}";
-		}
-
-		public float CalcDistWeighted(ColorYCbCr other, float yWeight = 4) {
-			var dy = (y - other.y) * (y - other.y) * yWeight;
-			var dcb = (cb - other.cb) * (cb - other.cb);
-			var dcr = (cr - other.cr) * (cr - other.cr);
-
-			return MathF.Sqrt(dy + dcb + dcr);
-		}
-
-		public static ColorYCbCr operator+(ColorYCbCr left, ColorYCbCr right)
-		{
-			return new ColorYCbCr(
-				left.y + right.y,
-				left.cb + right.cb,
-				left.cr + right.cr);
-		}
-
-		public static ColorYCbCr operator/(ColorYCbCr left, float right)
-		{
-			return new ColorYCbCr(
-				left.y / right,
-				left.cb / right,
-				left.cr / right);
-		}
-
-		public Rgba32 ToRgba32() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), 255);
 		}
 	}
 

--- a/BCnEnc.Net/Shared/Colors.cs
+++ b/BCnEnc.Net/Shared/Colors.cs
@@ -1,26 +1,18 @@
 using System;
 using System.Numerics;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
 	public struct ColorRgba32 : IEquatable<ColorRgba32>
 	{
 		public byte r, g, b, a;
+
 		public ColorRgba32(byte r, byte g, byte b, byte a)
 		{
 			this.r = r;
 			this.g = g;
 			this.b = b;
 			this.a = a;
-		}
-
-		public ColorRgba32(Rgba32 color)
-		{
-			this.r = color.R;
-			this.g = color.G;
-			this.b = color.B;
-			this.a = color.A;
 		}
 
 		public bool Equals(ColorRgba32 other)
@@ -171,14 +163,11 @@ namespace BCnEncoder.Shared
 			);
 		}
 
+		public static implicit operator ColorRgba32(ColorRgb24 d) => new ColorRgba32(d.r, d.g, d.b, 255);
+
 		public override string ToString()
 		{
 			return $"r : {r} g : {g} b : {b} a : {a}";
-		}
-
-		public Rgba32 ToRgba32()
-		{
-			return new Rgba32(r, g, b, a);
 		}
 	}
 
@@ -222,17 +211,6 @@ namespace BCnEncoder.Shared
 			var fr = (float)rgba.r / 255;
 			var fg = (float)rgba.g / 255;
 			var fb = (float)rgba.b / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-		}
-
-		public ColorYCbCr(Rgba32 rgb)
-		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
 
 			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
 			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
@@ -291,15 +269,6 @@ namespace BCnEncoder.Shared
 				left.y / right,
 				left.cb / right,
 				left.cr / right);
-		}
-
-		public Rgba32 ToRgba32()
-		{
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), 255);
 		}
 	}
 
@@ -476,7 +445,7 @@ namespace BCnEncoder.Shared
 		}
 	}
 
-	internal struct ColorRgb565 : IEquatable<ColorRgb565>
+	public struct ColorRgb565 : IEquatable<ColorRgb565>
 	{
 		public bool Equals(ColorRgb565 other)
 		{
@@ -511,45 +480,56 @@ namespace BCnEncoder.Shared
 
 		public ushort data;
 
-		public byte R {
-			readonly get {
+		public byte R
+		{
+			readonly get
+			{
 				var r5 = (data & RedMask) >> RedShift;
 				return (byte)((r5 << 3) | (r5 >> 2));
 			}
-			set {
+			set
+			{
 				var r5 = value >> 3;
 				data = (ushort)(data & ~RedMask);
 				data = (ushort)(data | (r5 << RedShift));
 			}
 		}
 
-		public byte G {
-			readonly get {
+		public byte G
+		{
+			readonly get
+			{
 				var g6 = (data & GreenMask) >> GreenShift;
 				return (byte)((g6 << 2) | (g6 >> 4));
 			}
-			set {
+			set
+			{
 				var g6 = value >> 2;
 				data = (ushort)(data & ~GreenMask);
 				data = (ushort)(data | (g6 << GreenShift));
 			}
 		}
 
-		public byte B {
-			readonly get {
+		public byte B
+		{
+			readonly get
+			{
 				var b5 = data & BlueMask;
 				return (byte)((b5 << 3) | (b5 >> 2));
 			}
-			set {
+			set
+			{
 				var b5 = value >> 3;
 				data = (ushort)(data & ~BlueMask);
 				data = (ushort)(data | b5);
 			}
 		}
 
-		public int RawR {
+		public int RawR
+		{
 			readonly get { return (data & RedMask) >> RedShift; }
-			set {
+			set
+			{
 				if (value > 31) value = 31;
 				if (value < 0) value = 0;
 				data = (ushort)(data & ~RedMask);
@@ -557,9 +537,11 @@ namespace BCnEncoder.Shared
 			}
 		}
 
-		public int RawG {
+		public int RawG
+		{
 			readonly get { return (data & GreenMask) >> GreenShift; }
-			set {
+			set
+			{
 				if (value > 63) value = 63;
 				if (value < 0) value = 0;
 				data = (ushort)(data & ~GreenMask);
@@ -567,9 +549,11 @@ namespace BCnEncoder.Shared
 			}
 		}
 
-		public int RawB {
+		public int RawB
+		{
 			readonly get { return data & BlueMask; }
-			set {
+			set
+			{
 				if (value > 31) value = 31;
 				if (value < 0) value = 0;
 				data = (ushort)(data & ~BlueMask);
@@ -585,14 +569,16 @@ namespace BCnEncoder.Shared
 			B = b;
 		}
 
-		public ColorRgb565(Vector3 colorVector) {
+		public ColorRgb565(Vector3 colorVector)
+		{
 			data = 0;
 			R = ByteHelper.ClampToByte(colorVector.X * 255);
 			G = ByteHelper.ClampToByte(colorVector.Y * 255);
 			B = ByteHelper.ClampToByte(colorVector.Z * 255);
 		}
 
-		public ColorRgb565(ColorRgb24 color) {
+		public ColorRgb565(ColorRgb24 color)
+		{
 			data = 0;
 			R = color.r;
 			G = color.g;
@@ -604,18 +590,21 @@ namespace BCnEncoder.Shared
 			return new ColorRgb24(R, G, B);
 		}
 
-		public override string ToString() {
+		public override string ToString()
+		{
 			return $"r : {R} g : {G} b : {B}";
 		}
 
-		public ColorRgba32 ToColorRgba32() {
+		public ColorRgba32 ToColorRgba32()
+		{
 			return new ColorRgba32(R, G, B, 255);
 		}
 	}
 
-	internal struct ColorRgb24 : IEquatable<ColorRgb24>
+	public struct ColorRgb24 : IEquatable<ColorRgb24>
 	{
 		public byte r, g, b;
+
 		public ColorRgb24(byte r, byte g, byte b)
 		{
 			this.r = r;
@@ -623,22 +612,18 @@ namespace BCnEncoder.Shared
 			this.b = b;
 		}
 
-		public ColorRgb24(ColorRgb565 color) {
+		public ColorRgb24(ColorRgb565 color)
+		{
 			this.r = color.R;
 			this.g = color.G;
 			this.b = color.B;
 		}
 
-		public ColorRgb24(ColorRgba32 color) {
+		public ColorRgb24(ColorRgba32 color)
+		{
 			this.r = color.r;
 			this.g = color.g;
 			this.b = color.b;
-		}
-
-		public ColorRgb24(Rgba32 color) {
-			this.r = color.R;
-			this.g = color.G;
-			this.b = color.B;
 		}
 
 		public bool Equals(ColorRgb24 other)
@@ -706,7 +691,8 @@ namespace BCnEncoder.Shared
 			);
 		}
 
-		public override string ToString() {
+		public override string ToString()
+		{
 			return $"r : {r} g : {g} b : {b}";
 		}
 	}
@@ -762,20 +748,9 @@ namespace BCnEncoder.Shared
 			alpha = rgba.a / 255f;
 		}
 
-		public ColorYCbCrAlpha(Rgba32 rgb)
+
+		public ColorRgb565 ToColorRgb565()
 		{
-			var fr = (float)rgb.R / 255;
-			var fg = (float)rgb.G / 255;
-			var fb = (float)rgb.B / 255;
-
-			y = 0.2989f * fr + 0.5866f * fg + 0.1145f * fb;
-			cb = -0.1687f * fr - 0.3313f * fg + 0.5000f * fb;
-			cr = 0.5000f * fr - 0.4184f * fg - 0.0816f * fb;
-			alpha = rgb.A / 255f;
-		}
-
-
-		public ColorRgb565 ToColorRgb565() {
 			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
 			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
 			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
@@ -783,7 +758,8 @@ namespace BCnEncoder.Shared
 			return new ColorRgb565((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
 		}
 
-		public override string ToString() {
+		public override string ToString()
+		{
 			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
 			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
 			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
@@ -791,7 +767,8 @@ namespace BCnEncoder.Shared
 			return $"r : {r * 255} g : {g * 255} b : {b * 255}";
 		}
 
-		public float CalcDistWeighted(ColorYCbCrAlpha other, float yWeight = 4, float aWeight = 1) {
+		public float CalcDistWeighted(ColorYCbCrAlpha other, float yWeight = 4, float aWeight = 1)
+		{
 			var dy = (y - other.y) * (y - other.y) * yWeight;
 			var dcb = (cb - other.cb) * (cb - other.cb);
 			var dcr = (cr - other.cr) * (cr - other.cr);
@@ -800,7 +777,7 @@ namespace BCnEncoder.Shared
 			return MathF.Sqrt(dy + dcb + dcr + da);
 		}
 
-		public static ColorYCbCrAlpha operator+(ColorYCbCrAlpha left, ColorYCbCrAlpha right)
+		public static ColorYCbCrAlpha operator +(ColorYCbCrAlpha left, ColorYCbCrAlpha right)
 		{
 			return new ColorYCbCrAlpha(
 				left.y + right.y,
@@ -809,7 +786,7 @@ namespace BCnEncoder.Shared
 				left.alpha + right.alpha);
 		}
 
-		public static ColorYCbCrAlpha operator/(ColorYCbCrAlpha left, float right)
+		public static ColorYCbCrAlpha operator /(ColorYCbCrAlpha left, float right)
 		{
 			return new ColorYCbCrAlpha(
 				left.y / right,
@@ -817,32 +794,28 @@ namespace BCnEncoder.Shared
 				left.cr / right,
 				left.alpha / right);
 		}
-
-		public Rgba32 ToRgba32() {
-			var r = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 0.0000 * cb + 1.4022 * cr)));
-			var g = Math.Max(0.0f, Math.Min(1.0f, (float)(y - 0.3456 * cb - 0.7145 * cr)));
-			var b = Math.Max(0.0f, Math.Min(1.0f, (float)(y + 1.7710 * cb + 0.0000 * cr)));
-
-			return new Rgba32((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), (byte)(alpha * 255));
-		}
 	}
 
-	internal struct ColorXyz {
+	internal struct ColorXyz
+	{
 		public float x;
 		public float y;
 		public float z;
 
-		public ColorXyz(float x, float y, float z) {
+		public ColorXyz(float x, float y, float z)
+		{
 			this.x = x;
 			this.y = y;
 			this.z = z;
 		}
 
-		public ColorXyz(ColorRgb24 color) {
+		public ColorXyz(ColorRgb24 color)
+		{
 			this = ColorToXyz(color);
 		}
 
-		public static ColorXyz ColorToXyz(ColorRgb24 color) {
+		public static ColorXyz ColorToXyz(ColorRgb24 color)
+		{
 			var r = PivotRgb(color.r / 255.0f);
 			var g = PivotRgb(color.g / 255.0f);
 			var b = PivotRgb(color.b / 255.0f);
@@ -851,41 +824,44 @@ namespace BCnEncoder.Shared
 			return new ColorXyz(r * 0.4124f + g * 0.3576f + b * 0.1805f, r * 0.2126f + g * 0.7152f + b * 0.0722f, r * 0.0193f + g * 0.1192f + b * 0.9505f);
 		}
 
-		private static float PivotRgb(float n) {
+		private static float PivotRgb(float n)
+		{
 			return (n > 0.04045f ? MathF.Pow((n + 0.055f) / 1.055f, 2.4f) : n / 12.92f) * 100;
 		}
 	}
 
-	internal struct ColorLab {
+	internal struct ColorLab
+	{
 		public float l;
 		public float a;
 		public float b;
 
-		public ColorLab(float l, float a, float b) {
+		public ColorLab(float l, float a, float b)
+		{
 			this.l = l;
 			this.a = a;
 			this.b = b;
 		}
 
-		public ColorLab(ColorRgb24 color) {
+		public ColorLab(ColorRgb24 color)
+		{
 			this = ColorToLab(color);
 		}
 
-		public ColorLab(ColorRgba32 color) {
+		public ColorLab(ColorRgba32 color)
+		{
 			this = ColorToLab(new ColorRgb24(color.r, color.g, color.b));
 		}
 
-		public ColorLab(Rgba32 color) {
-			this = ColorToLab(new ColorRgb24(color.R, color.G, color.B));
-		}
-
-		public static ColorLab ColorToLab(ColorRgb24 color) {
+		public static ColorLab ColorToLab(ColorRgb24 color)
+		{
 			var xyz = new ColorXyz(color);
 			return XyzToLab(xyz);
 		}
 
 
-		public static ColorLab XyzToLab(ColorXyz xyz) {
+		public static ColorLab XyzToLab(ColorXyz xyz)
+		{
 			var refX = 95.047f; // Observer= 2°, Illuminant= D65
 			var refY = 100.000f;
 			var refZ = 108.883f;
@@ -897,7 +873,8 @@ namespace BCnEncoder.Shared
 			return new ColorLab(116 * y - 16, 500 * (x - y), 200 * (y - z));
 		}
 
-		private static float PivotXyz(float n) {
+		private static float PivotXyz(float n)
+		{
 			var i = MathF.Cbrt(n);
 			return n > 0.008856f ? i : 7.787f * n + 16 / 116f;
 		}

--- a/BCnEnc.Net/Shared/ComponentHelper.cs
+++ b/BCnEnc.Net/Shared/ComponentHelper.cs
@@ -1,0 +1,87 @@
+using System;
+using BCnEncoder.Encoder;
+
+namespace BCnEncoder.Shared
+{
+	internal static class ComponentHelper
+	{
+		public static ColorRgba32 ComponentToColor(Bc4Component component, byte componentValue)
+		{
+			switch (component)
+			{
+				case Bc4Component.R:
+					return new ColorRgba32(componentValue, 0, 0, 255);
+
+				case Bc4Component.G:
+					return new ColorRgba32(0, componentValue, 0, 255);
+
+				case Bc4Component.B:
+					return new ColorRgba32(0, 0, componentValue, 255);
+
+				case Bc4Component.A:
+					return new ColorRgba32(0, 0, 0, componentValue);
+
+				case Bc4Component.Luminance:
+					return new ColorRgba32(componentValue, componentValue, componentValue, 255);
+
+				default:
+					throw new InvalidOperationException("Unsupported component.");
+			}
+		}
+
+		public static ColorRgba32 ComponentToColor(ColorRgba32 existingColor, Bc4Component component, byte componentValue)
+		{
+			switch (component)
+			{
+				case Bc4Component.R:
+					existingColor.r = componentValue;
+					break;
+
+				case Bc4Component.G:
+					existingColor.g = componentValue;
+					break;
+
+				case Bc4Component.B:
+					existingColor.b = componentValue;
+					break;
+
+				case Bc4Component.A:
+					existingColor.a = componentValue;
+					break;
+
+				case Bc4Component.Luminance:
+					existingColor.r = existingColor.g = existingColor.b = componentValue;
+					break;
+
+				default:
+					throw new InvalidOperationException("Unsupported component.");
+			}
+
+			return existingColor;
+		}
+
+		public static byte ColorToComponent(ColorRgba32 color, Bc4Component component)
+		{
+			switch (component)
+			{
+				case Bc4Component.R:
+					return color.r;
+
+				case Bc4Component.G:
+					return color.g;
+
+				case Bc4Component.B:
+					return color.b;
+
+				case Bc4Component.A:
+					return color.a;
+
+				case Bc4Component.Luminance:
+					return (byte)(new ColorYCbCr(color).y * 255);
+
+				default:
+					throw new InvalidOperationException("Unsupported component.");
+			}
+		}
+	}
+}

--- a/BCnEnc.Net/Shared/CompressionFormat.cs
+++ b/BCnEnc.Net/Shared/CompressionFormat.cs
@@ -59,11 +59,11 @@ namespace BCnEncoder.Shared
 		/// </summary>
 		Atc,
 		/// <summary>
-		/// ATC / Adreno Texture Compression encoding. Derivative of BC1. Good for sharp alpha transitions.
+		/// ATC / Adreno Texture Compression encoding. Derivative of BC2. Good for sharp alpha transitions.
 		/// </summary>
 		AtcExplicitAlpha,
 		/// <summary>
-		/// ATC / Adreno Texture Compression encoding. Derivative of BC1. Good for smooth alpha transitions.
+		/// ATC / Adreno Texture Compression encoding. Derivative of BC3. Good for smooth alpha transitions.
 		/// </summary>
 		AtcInterpolatedAlpha
 	}

--- a/BCnEnc.Net/Shared/EncodedBlocks.cs
+++ b/BCnEnc.Net/Shared/EncodedBlocks.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
@@ -53,11 +52,11 @@ namespace BCnEncoder.Shared
 				var color = colors[colorIndex];
 				if (useAlpha && colorIndex == 3)
 				{
-					pixels[i] = new Rgba32(0, 0, 0, 0);
+					pixels[i] = new ColorRgba32(0, 0, 0, 0);
 				}
 				else
 				{
-					pixels[i] = new Rgba32(color.r, color.g, color.b, 255);
+					pixels[i] = new ColorRgba32(color.r, color.g, color.b, 255);
 				}
 			}
 			return output;
@@ -107,7 +106,7 @@ namespace BCnEncoder.Shared
 				var colorIndex = (int)((colorIndices >> (i * 2)) & 0b11);
 				var color = colors[colorIndex];
 
-				pixels[i] = new Rgba32(color.r, color.g, color.b, GetAlpha(i));
+				pixels[i] = new ColorRgba32(color.r, color.g, color.b, GetAlpha(i));
 			}
 			return output;
 		}
@@ -170,7 +169,7 @@ namespace BCnEncoder.Shared
 				var colorIndex = (int)((colorIndices >> (i * 2)) & 0b11);
 				var color = colors[colorIndex];
 
-				pixels[i] = new Rgba32(color.r, color.g, color.b, alphas[i]);
+				pixels[i] = new ColorRgba32(color.r, color.g, color.b, alphas[i]);
 			}
 			return output;
 		}
@@ -209,7 +208,7 @@ namespace BCnEncoder.Shared
 				for (var i = 0; i < pixels.Length; i++)
 				{
 					var index = GetComponentIndex(i);
-					pixels[i] = new Rgba32(reds[index], reds[index], reds[index], 255);
+					pixels[i] = new ColorRgba32(reds[index], reds[index], reds[index], 255);
 				}
 			}
 			else
@@ -217,7 +216,7 @@ namespace BCnEncoder.Shared
 				for (var i = 0; i < pixels.Length; i++)
 				{
 					var index = GetComponentIndex(i);
-					pixels[i] = new Rgba32(reds[index], 0, 0, 255);
+					pixels[i] = new ColorRgba32(reds[index], 0, 0, 255);
 				}
 			}
 
@@ -273,7 +272,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				pixels[i] = new Rgba32(reds[i], greens[i], 0, 255);
+				pixels[i] = new ColorRgba32(reds[i], greens[i], 0, 255);
 			}
 
 			return output;
@@ -319,7 +318,7 @@ namespace BCnEncoder.Shared
 
 				var color = this.color0.Mode == 0 ? color0.InterpolateThird(color1, colorIndex) : colors[colorIndex];
 
-				pixels[i] = new Rgba32(color.r, color.g, color.b, 255);
+				pixels[i] = new ColorRgba32(color.r, color.g, color.b, 255);
 			}
 			return output;
 		}
@@ -439,7 +438,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				pixels[i].A = alphas.GetAlpha(i);
+				pixels[i].a = alphas.GetAlpha(i);
 			}
 			return output;
 		}
@@ -460,7 +459,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				pixels[i].A = componentValues[i];
+				pixels[i].a = componentValues[i];
 			}
 			return output;
 		}

--- a/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace BCnEncoder.Shared
+namespace BCnEncoder.Shared.ImageFiles
 {
 	public class DdsFile
 	{

--- a/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
@@ -68,20 +68,21 @@ namespace BCnEncoder.Shared.ImageFiles
 
 					for (var mip = 0; mip < mipMapCount; mip++)
 					{
-						var mipWidth = header.dwWidth >> mip;
-						var mipHeight = header.dwHeight >> mip;
-						// Saw this in a 1024x512 dds with 11 mipMapCount. Height became 0 (should be 1)
-						mipWidth = Math.Max(mipWidth, 1);
-						mipHeight = Math.Max(mipHeight, 1);
+						MipMapper.CalculateMipLevelSize(
+							(int)header.dwWidth,
+							(int)header.dwHeight,
+							mip,
+							out var mipWidth,
+							out var mipHeight);
 
 						if (mip > 0) //Calculate new byteSize
 						{
-							sizeInBytes = GetSizeInBytes(format, mipWidth, mipHeight);
+							sizeInBytes = GetSizeInBytes(format, (uint)mipWidth, (uint)mipHeight);
 						}
 
 						var data = new byte[sizeInBytes];
 						br.Read(data);
-						output.Faces[face].MipMaps[mip] = new DdsMipMap(data, mipWidth, mipHeight);
+						output.Faces[face].MipMaps[mip] = new DdsMipMap(data, (uint)mipWidth, (uint)mipHeight);
 					}
 				}
 
@@ -155,17 +156,8 @@ namespace BCnEncoder.Shared.ImageFiles
 			uint sizeInBytes;
 			if (format.IsCompressedFormat())
 			{
-				sizeInBytes = (uint)Math.Max(1, ((width + 3) & ~3) >> 2) * (uint)Math.Max(1, ((height + 3) & ~3) >> 2);
-				if (format == DxgiFormat.DxgiFormatBc1Unorm ||
-					format == DxgiFormat.DxgiFormatBc1UnormSrgb ||
-					format == DxgiFormat.DxgiFormatBc1Typeless)
-				{
-					sizeInBytes *= 8;
-				}
-				else
-				{
-					sizeInBytes *= 16;
-				}
+				sizeInBytes = (uint)ImageToBlocks.CalculateNumOfBlocks((int)width, (int)height);
+				sizeInBytes *= (uint)format.GetByteSize();
 			}
 			else
 			{
@@ -198,7 +190,7 @@ namespace BCnEncoder.Shared.ImageFiles
 		public uint dwCaps4;
 		public uint dwReserved2;
 
-		public static (DdsHeader, DdsHeaderDx10) InitializeCompressed(int width, int height, DxgiFormat format)
+		public static (DdsHeader, DdsHeaderDx10) InitializeCompressed(int width, int height, DxgiFormat format, bool preferDxt10Header)
 		{
 			var header = new DdsHeader();
 			var dxt10Header = new DdsHeaderDx10();
@@ -211,91 +203,139 @@ namespace BCnEncoder.Shared.ImageFiles
 			header.dwMipMapCount = 1;
 			header.dwCaps = HeaderCaps.DdscapsTexture;
 
-			switch (format)
+			if (preferDxt10Header)
 			{
-				case DxgiFormat.DxgiFormatBc1Unorm:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Dxt1
-					};
-					break;
+				// ATC formats cannot be written to DXT10 header due to lack of a DxgiFormat enum
+				switch (format)
+				{
+					case DxgiFormat.DxgiFormatAtcExt:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Atc
+						};
+						break;
 
-				case DxgiFormat.DxgiFormatBc2Unorm:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Dxt3
-					};
-					break;
+					case DxgiFormat.DxgiFormatAtcExplicitAlphaExt:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Atci
+						};
+						break;
 
-				case DxgiFormat.DxgiFormatBc3Unorm:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Dxt5
-					};
-					break;
+					case DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Atca
+						};
+						break;
 
-				case DxgiFormat.DxgiFormatBc4Unorm:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Ati1
-					};
-					break;
+					default:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Dx10
+						};
+						dxt10Header.arraySize = 1;
+						dxt10Header.dxgiFormat = format;
+						dxt10Header.resourceDimension = D3D10ResourceDimension.D3D10ResourceDimensionTexture2D;
+						break;
+				}
+			}
+			else
+			{
+				switch (format)
+				{
+					case DxgiFormat.DxgiFormatBc1Unorm:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Dxt1
+						};
+						break;
 
-				case DxgiFormat.DxgiFormatBc5Unorm:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Ati2
-					};
-					break;
+					case DxgiFormat.DxgiFormatBc2Unorm:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Dxt3
+						};
+						break;
 
-				case DxgiFormat.DxgiFormatAtc:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Atc
-					};
-					break;
+					case DxgiFormat.DxgiFormatBc3Unorm:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Dxt5
+						};
+						break;
 
-				case DxgiFormat.DxgiFormatAtcExplicitAlpha:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Atci
-					};
-					break;
+					case DxgiFormat.DxgiFormatBc4Unorm:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Bc4U
+						};
+						break;
 
-				case DxgiFormat.DxgiFormatAtcInterpolatedAlpha:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Atca
-					};
-					break;
+					case DxgiFormat.DxgiFormatBc5Unorm:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Ati2
+						};
+						break;
 
-				default:
-					header.ddsPixelFormat = new DdsPixelFormat
-					{
-						dwSize = 32,
-						dwFlags = PixelFormatFlags.DdpfFourcc,
-						dwFourCc = DdsPixelFormat.Dx10
-					};
-					dxt10Header.arraySize = 1;
-					dxt10Header.dxgiFormat = format;
-					dxt10Header.resourceDimension = D3D10ResourceDimension.D3D10ResourceDimensionTexture2D;
-					break;
+					case DxgiFormat.DxgiFormatAtcExt:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Atc
+						};
+						break;
+
+					case DxgiFormat.DxgiFormatAtcExplicitAlphaExt:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Atci
+						};
+						break;
+
+					case DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Atca
+						};
+						break;
+
+					default:
+						header.ddsPixelFormat = new DdsPixelFormat
+						{
+							dwSize = 32,
+							dwFlags = PixelFormatFlags.DdpfFourcc,
+							dwFourCc = DdsPixelFormat.Dx10
+						};
+						dxt10Header.arraySize = 1;
+						dxt10Header.dxgiFormat = format;
+						dxt10Header.resourceDimension = D3D10ResourceDimension.D3D10ResourceDimensionTexture2D;
+						break;
+				}
 			}
 
 			return (header, dxt10Header);
@@ -329,7 +369,7 @@ namespace BCnEncoder.Shared.ImageFiles
 				header.ddsPixelFormat = new DdsPixelFormat()
 				{
 					dwSize = 32,
-					dwFlags = PixelFormatFlags.DdpfLuminance | PixelFormatFlags.DdpfAlphapixels,
+					dwFlags = PixelFormatFlags.DdpfLuminance | PixelFormatFlags.DdpfAlphaPixels,
 					dwRgbBitCount = 16,
 					dwRBitMask = 0xFF,
 					dwGBitMask = 0xFF00
@@ -341,7 +381,7 @@ namespace BCnEncoder.Shared.ImageFiles
 				header.ddsPixelFormat = new DdsPixelFormat()
 				{
 					dwSize = 32,
-					dwFlags = PixelFormatFlags.DdpfRgb | PixelFormatFlags.DdpfAlphapixels,
+					dwFlags = PixelFormatFlags.DdpfRgb | PixelFormatFlags.DdpfAlphaPixels,
 					dwRgbBitCount = 32,
 					dwRBitMask = 0xFF,
 					dwGBitMask = 0xFF00,
@@ -355,7 +395,7 @@ namespace BCnEncoder.Shared.ImageFiles
 				header.ddsPixelFormat = new DdsPixelFormat()
 				{
 					dwSize = 32,
-					dwFlags = PixelFormatFlags.DdpfRgb | PixelFormatFlags.DdpfAlphapixels,
+					dwFlags = PixelFormatFlags.DdpfRgb | PixelFormatFlags.DdpfAlphaPixels,
 					dwRgbBitCount = 32,
 					dwRBitMask = 0xFF0000,
 					dwGBitMask = 0xFF00,
@@ -375,17 +415,32 @@ namespace BCnEncoder.Shared.ImageFiles
 
 	public struct DdsPixelFormat
 	{
-		public const uint Dxt1 = 0x31545844U;
-		public const uint Dxt2 = 0x32545844U;
-		public const uint Dxt3 = 0x33545844U;
-		public const uint Dxt4 = 0x34545844U;
-		public const uint Dxt5 = 0x35545844U;
-		public const uint Ati1 = 0x41544931U;
-		public const uint Ati2 = 0x41544932U;
-		public const uint Atc = 0x42544320U;
-		public const uint Atci = 0x42544349U;
-		public const uint Atca = 0x42544341U;
-		public const uint Dx10 = 0x30315844U;
+		public static readonly uint Dx10 = MakeFourCc('D', 'X', '1', '0');
+		
+		public static readonly uint Dxt1 = MakeFourCc('D', 'X', 'T', '1');
+		public static readonly uint Dxt2 = MakeFourCc('D', 'X', 'T', '2');
+		public static readonly uint Dxt3 = MakeFourCc('D', 'X', 'T', '3');
+		public static readonly uint Dxt4 = MakeFourCc('D', 'X', 'T', '4');
+		public static readonly uint Dxt5 = MakeFourCc('D', 'X', 'T', '5');
+		public static readonly uint Ati1 = MakeFourCc('A', 'T', 'I', '1');
+		public static readonly uint Ati2 = MakeFourCc('A', 'T', 'I', '2');
+		public static readonly uint Atc  = MakeFourCc('A', 'T', 'C', ' ');
+		public static readonly uint Atci = MakeFourCc('A', 'T', 'C', 'I');
+		public static readonly uint Atca = MakeFourCc('A', 'T', 'C', 'A');
+
+		public static readonly uint Bc4S = MakeFourCc('B', 'C', '4', 'S');
+		public static readonly uint Bc4U = MakeFourCc('B', 'C', '4', 'U');
+		public static readonly uint Bc5S = MakeFourCc('B', 'C', '5', 'S');
+		public static readonly uint Bc5U = MakeFourCc('B', 'C', '5', 'U');
+
+		private static uint MakeFourCc(char c0, char c1, char c2, char c3)
+		{
+			uint result = c0;
+			result |= (uint)c1 << 8;
+			result |= (uint)c2 << 16;
+			result |= (uint)c3 << 24;
+			return result;
+		}
 
 		public uint dwSize;
 		public PixelFormatFlags dwFlags;
@@ -402,33 +457,20 @@ namespace BCnEncoder.Shared.ImageFiles
 			{
 				if (dwFlags.HasFlag(PixelFormatFlags.DdpfFourcc))
 				{
-					switch (dwFourCc)
-					{
-						case Dxt1:
-							return DxgiFormat.DxgiFormatBc1Unorm;
-						case Dxt2:
-						case Dxt3:
-							return DxgiFormat.DxgiFormatBc2Unorm;
-						case Dxt4:
-						case Dxt5:
-							return DxgiFormat.DxgiFormatBc3Unorm;
-						case Ati1:
-							return DxgiFormat.DxgiFormatBc4Unorm;
-						case Ati2:
-							return DxgiFormat.DxgiFormatBc5Unorm;
-						case Atc:
-							return DxgiFormat.DxgiFormatAtc;
-						case Atci:
-							return DxgiFormat.DxgiFormatAtcExplicitAlpha;
-						case Atca:
-							return DxgiFormat.DxgiFormatAtcInterpolatedAlpha;
-					}
+					if (dwFourCc == Dxt1) return DxgiFormat.DxgiFormatBc1Unorm;
+					if (dwFourCc == Dxt2 || dwFourCc == Dxt3) return DxgiFormat.DxgiFormatBc2Unorm;
+					if (dwFourCc == Dxt4 || dwFourCc == Dxt5) return DxgiFormat.DxgiFormatBc3Unorm;
+					if (dwFourCc == Ati1 || dwFourCc == Bc4S || dwFourCc == Bc4U) return DxgiFormat.DxgiFormatBc4Unorm;
+					if (dwFourCc == Ati2 || dwFourCc == Bc5S || dwFourCc == Bc5U) return DxgiFormat.DxgiFormatBc5Unorm;
+					if (dwFourCc == Atc) return DxgiFormat.DxgiFormatAtcExt;
+					if (dwFourCc == Atci) return DxgiFormat.DxgiFormatAtcExplicitAlphaExt;
+					if (dwFourCc == Atca) return DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt;
 				}
 				else
 				{
 					if (dwFlags.HasFlag(PixelFormatFlags.DdpfRgb)) // RGB/A
 					{
-						if (dwFlags.HasFlag(PixelFormatFlags.DdpfAlphapixels)) //RGBA
+						if (dwFlags.HasFlag(PixelFormatFlags.DdpfAlphaPixels)) //RGBA
 						{
 							if (dwRgbBitCount == 32)
 							{
@@ -458,7 +500,7 @@ namespace BCnEncoder.Shared.ImageFiles
 					}
 					else if (dwFlags.HasFlag(PixelFormatFlags.DdpfLuminance)) // R/RG
 					{
-						if (dwFlags.HasFlag(PixelFormatFlags.DdpfAlphapixels)) // RG
+						if (dwFlags.HasFlag(PixelFormatFlags.DdpfAlphaPixels)) // RG
 						{
 							if (dwRgbBitCount == 16)
 							{
@@ -486,13 +528,6 @@ namespace BCnEncoder.Shared.ImageFiles
 
 		public bool IsDxt10Format => (dwFlags & PixelFormatFlags.DdpfFourcc) == PixelFormatFlags.DdpfFourcc
 									 && dwFourCc == Dx10;
-
-		public bool IsDxt1To5CompressedFormat => (dwFlags & PixelFormatFlags.DdpfFourcc) == PixelFormatFlags.DdpfFourcc
-									 && (dwFourCc == Dxt1
-										 || dwFourCc == Dxt2
-										 || dwFourCc == Dxt3
-										 || dwFourCc == Dxt4
-										 || dwFourCc == Dxt5);
 	}
 
 	public struct DdsHeaderDx10
@@ -643,7 +678,7 @@ namespace BCnEncoder.Shared.ImageFiles
 		/// <summary>
 		/// Texture contains alpha data; dwRGBAlphaBitMask contains valid data.
 		/// </summary>
-		DdpfAlphapixels = 0x1,
+		DdpfAlphaPixels = 0x1,
 		/// <summary>
 		/// Used in some older DDS files for alpha channel only uncompressed data (dwRGBBitCount contains the alpha channel bitcount; dwABitMask contains valid data)
 		/// </summary>
@@ -798,10 +833,10 @@ namespace BCnEncoder.Shared.ImageFiles
 		DxgiFormatV408,
 		DxgiFormatForceUint,
 
-		// Added here due to missing documentation of an official value
-		DxgiFormatAtc = 300,
-		DxgiFormatAtcExplicitAlpha,
-		DxgiFormatAtcInterpolatedAlpha
+		// Added here due to lack of an official value
+		DxgiFormatAtcExt = 300,
+		DxgiFormatAtcExplicitAlphaExt,
+		DxgiFormatAtcInterpolatedAlphaExt
 	};
 
 	public static class DxgiFormatExtensions
@@ -1016,6 +1051,12 @@ namespace BCnEncoder.Shared.ImageFiles
 					return 2;
 				case DxgiFormat.DxgiFormatB4G4R4A4Unorm:
 					return 2;
+				case DxgiFormat.DxgiFormatAtcExt:
+					return 8;
+				case DxgiFormat.DxgiFormatAtcExplicitAlphaExt:
+					return 16;
+				case DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt:
+					return 16;
 			}
 			return 4;
 		}
@@ -1045,6 +1086,9 @@ namespace BCnEncoder.Shared.ImageFiles
 				case DxgiFormat.DxgiFormatBc7Typeless:
 				case DxgiFormat.DxgiFormatBc7Unorm:
 				case DxgiFormat.DxgiFormatBc7UnormSrgb:
+				case DxgiFormat.DxgiFormatAtcExt:
+				case DxgiFormat.DxgiFormatAtcExplicitAlphaExt:
+				case DxgiFormat.DxgiFormatAtcInterpolatedAlphaExt:
 					return true;
 
 				default:

--- a/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
@@ -7,7 +7,7 @@ namespace BCnEncoder.Shared.ImageFiles
 	/// <summary>
 	/// The format identifier of an image file.
 	/// </summary>
-	public enum ImagefileFormat
+	public enum ImageFileFormat
 	{
 		/// <summary>
 		/// Represents the KTX image file format.
@@ -37,19 +37,19 @@ namespace BCnEncoder.Shared.ImageFiles
 		/// </summary>
 		/// <param name="stream">The stream of data to identify.</param>
 		/// <returns>The format this image file may contain.</returns>
-		public static ImagefileFormat DetermineImageFormat(Stream stream)
+		public static ImageFileFormat DetermineImageFormat(Stream stream)
 		{
 			if (IsDds(stream))
 			{
-				return ImagefileFormat.Dds;
+				return ImageFileFormat.Dds;
 			}
 
 			if (IsKtx(stream))
 			{
-				return ImagefileFormat.Ktx;
+				return ImageFileFormat.Ktx;
 			}
 
-			return ImagefileFormat.Unknown;
+			return ImageFileFormat.Unknown;
 		}
 
 		private static bool IsDds(Stream stream)

--- a/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/ImageFile.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace BCnEncoder.Shared.ImageFiles
+{
+	/// <summary>
+	/// The format identifier of an image file.
+	/// </summary>
+	public enum ImagefileFormat
+	{
+		/// <summary>
+		/// Represents the KTX image file format.
+		/// </summary>
+		Ktx,
+
+		/// <summary>
+		/// Represents the DDS image file format.
+		/// </summary>
+		Dds,
+
+		/// <summary>
+		/// Represents an unknown image file format.
+		/// </summary>
+		Unknown
+	}
+
+	/// <summary>
+	/// Static helper class to determine the format of an image file.
+	/// </summary>
+	public static class ImageFile
+	{
+		private static readonly byte[] ktx1Identifier = { 0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A };
+
+		/// <summary>
+		/// Determines the image file format of the given stream.
+		/// </summary>
+		/// <param name="stream">The stream of data to identify.</param>
+		/// <returns>The format this image file may contain.</returns>
+		public static ImagefileFormat DetermineImageFormat(Stream stream)
+		{
+			if (IsDds(stream))
+			{
+				return ImagefileFormat.Dds;
+			}
+
+			if (IsKtx(stream))
+			{
+				return ImagefileFormat.Ktx;
+			}
+
+			return ImagefileFormat.Unknown;
+		}
+
+		private static bool IsDds(Stream stream)
+		{
+			using var br = new BinaryReader(stream, Encoding.UTF8, true);
+
+			var magic = br.ReadUInt32();
+			stream.Position -= 4;
+
+			return magic == 0x20534444U;
+		}
+
+		private static bool IsKtx(Stream stream)
+		{
+			// Only checks for version 1
+			using var br = new BinaryReader(stream, Encoding.ASCII, true);
+
+			var identifier = br.ReadBytes(12);
+			stream.Position -= 12;
+
+			return identifier.SequenceEqual(ktx1Identifier);
+		}
+	}
+}

--- a/BCnEnc.Net/Shared/ImageFiles/KtxFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/KtxFile.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using static System.Text.Encoding;
 
-namespace BCnEncoder.Shared
+namespace BCnEncoder.Shared.ImageFiles
 {
 	/// <summary>
 	/// A representation of a ktx file.

--- a/BCnEnc.Net/Shared/ImageQuality.cs
+++ b/BCnEnc.Net/Shared/ImageQuality.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using SixLabors.ImageSharp.PixelFormats;
+using System;
 
 namespace BCnEncoder.Shared
 {
 	public class ImageQuality
 	{
-		public static float PeakSignalToNoiseRatio(ReadOnlySpan<Rgba32> original, ReadOnlySpan<Rgba32> other, bool countAlpha = true) {
+		public static float PeakSignalToNoiseRatio(ReadOnlySpan<ColorRgba32> original, ReadOnlySpan<ColorRgba32> other, bool countAlpha = true) {
 			if (original.Length != other.Length) {
 				throw new ArgumentException("Both spans should be the same length");
 			}
@@ -17,7 +16,7 @@ namespace BCnEncoder.Shared
 				error += (o.cb - c.cb) * (o.cb - c.cb);
 				error += (o.cr - c.cr) * (o.cr - c.cr);
 				if (countAlpha) {
-					error += (original[i].A - other[i].A) / 255.0f * ((original[i].A - other[i].A) / 255.0f);
+					error += (original[i].a - other[i].a) / 255.0f * ((original[i].a - other[i].a) / 255.0f);
 				}
 				
 			}
@@ -35,7 +34,7 @@ namespace BCnEncoder.Shared
 			return 20 * MathF.Log10(1 / MathF.Sqrt(error));
 		}
 
-		public static float PeakSignalToNoiseRatioLuminance(ReadOnlySpan<Rgba32> original, ReadOnlySpan<Rgba32> other, bool countAlpha = true) {
+		public static float PeakSignalToNoiseRatioLuminance(ReadOnlySpan<ColorRgba32> original, ReadOnlySpan<ColorRgba32> other, bool countAlpha = true) {
 			if (original.Length != other.Length) {
 				throw new ArgumentException("Both spans should be the same length");
 			}
@@ -45,7 +44,7 @@ namespace BCnEncoder.Shared
 				var c = new ColorYCbCr(other[i]);
 				error += (o.y - c.y) * (o.y - c.y);
 				if (countAlpha) {
-					error += (original[i].A - other[i].A) / 255.0f * ((original[i].A - other[i].A) / 255.0f);
+					error += (original[i].a - other[i].a) / 255.0f * ((original[i].a - other[i].a) / 255.0f);
 				}
 				
 			}

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -28,6 +28,7 @@ namespace BCnEncoder.Shared
 
 		internal static ColorRgba32[] ColorsFromRawBlocks(RawBlock4X4Rgba32[] blocks, int pixelWidth, int pixelHeight)
 		{
+			var blocksWidth = ((pixelWidth + 3) & ~3) >> 2;
 			var output = new ColorRgba32[pixelWidth * pixelHeight];
 
 			for (var y = 0; y < pixelHeight; y++)
@@ -39,7 +40,7 @@ namespace BCnEncoder.Shared
 					var blockInternalIndexX = x & 3;
 					var blockInternalIndexY = y & 3;
 
-					var blockIndex = blockIndexX + blockIndexY * 4;
+					var blockIndex = blockIndexX + blockIndexY * blocksWidth;
 
 					output[x + y * pixelWidth] = blocks[blockIndex][blockInternalIndexX, blockInternalIndexY];
 				}
@@ -56,6 +57,7 @@ namespace BCnEncoder.Shared
 		{
 			blocksWidth = ((image.Width + 3) & ~3) >> 2;
 			blocksHeight = ((image.Height + 3) & ~3) >> 2;
+			
 			var output = new RawBlock4X4Rgba32[blocksWidth * blocksHeight];
 
 			var span = image.Span;

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -52,7 +52,7 @@ namespace BCnEncoder.Shared
 
 		#region Image to blocks
 
-		internal static RawBlock4X4Rgba32[] ImageTo4X4(Memory2D<ColorRgba32> image, out int blocksWidth, out int blocksHeight)
+		internal static RawBlock4X4Rgba32[] ImageTo4X4(ReadOnlyMemory2D<ColorRgba32> image, out int blocksWidth, out int blocksHeight)
 		{
 			blocksWidth = ((image.Width + 3) & ~3) >> 2;
 			blocksHeight = ((image.Height + 3) & ~3) >> 2;

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -6,6 +6,51 @@ namespace BCnEncoder.Shared
 {
 	internal static class ImageToBlocks
 	{
+		#region Blocks to colors
+
+		internal static ColorRgba32[] ColorsFromRawBlocks(RawBlock4X4Rgba32[,] blocks, int pixelWidth, int pixelHeight)
+		{
+			var output = new ColorRgba32[pixelWidth * pixelHeight];
+
+			for (var y = 0; y < pixelHeight; y++)
+			{
+				for (var x = 0; x < pixelWidth; x++)
+				{
+					var blockIndexX = x >> 2;
+					var blockIndexY = y >> 2;
+					var blockInternalIndexX = x & 3;
+					var blockInternalIndexY = y & 3;
+
+					output[x + y * pixelWidth] = blocks[blockIndexX, blockIndexY][blockInternalIndexX, blockInternalIndexY];
+				}
+			}
+
+			return output;
+		}
+
+		internal static ColorRgba32[] ColorsFromRawBlocks(RawBlock4X4Rgba32[] blocks, int pixelWidth, int pixelHeight)
+		{
+			var output = new ColorRgba32[pixelWidth * pixelHeight];
+
+			for (var y = 0; y < pixelHeight; y++)
+			{
+				for (var x = 0; x < pixelWidth; x++)
+				{
+					var blockIndexX = x >> 2;
+					var blockIndexY = y >> 2;
+					var blockInternalIndexX = x & 3;
+					var blockInternalIndexY = y & 3;
+
+					var blockIndex = blockIndexX + blockIndexY * 4;
+
+					output[x + y * pixelWidth] = blocks[blockIndex][blockInternalIndexX, blockInternalIndexY];
+				}
+			}
+
+			return output;
+		}
+
+		#endregion
 
 		internal static RawBlock4X4Rgba32[] ImageTo4X4(ImageFrame<Rgba32> image, out int blocksWidth, out int blocksHeight)
 		{
@@ -65,66 +110,6 @@ namespace BCnEncoder.Shared
 						}
 					}
 					output[blocksWidth - 1 + i * blocksWidth] = lastBlock;
-				}
-			}
-
-			return output;
-		}
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[,] blocks, int blocksWidth, int blocksHeight)
-			=> ImageFromRawBlocks(blocks, blocksWidth, blocksHeight, blocksWidth * 4, blocksHeight * 4);
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[,] blocks, int blocksWidth, int blocksHeight, int pixelWidth, int pixelHeight)
-		{
-			var output = new Image<Rgba32>(pixelWidth, pixelHeight);
-
-			if (!output.TryGetSinglePixelSpan(out var pixels))
-			{
-				throw new Exception("Cannot get pixel span.");
-			}
-
-			for (var y = 0; y < output.Height; y++)
-			{
-				for (var x = 0; x < output.Width; x++)
-				{
-					var blockIndexX = x >> 2;
-					var blockIndexY = y >> 2;
-					var blockInternalIndexX = x & 3;
-					var blockInternalIndexY = y & 3;
-
-					pixels[x + y * output.Width] =
-						blocks[blockIndexX, blockIndexY]
-							[blockInternalIndexX, blockInternalIndexY];
-				}
-			}
-
-			return output;
-		}
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[] blocks, int blocksWidth, int blocksHeight)
-			=> ImageFromRawBlocks(blocks, blocksWidth, blocksHeight, blocksWidth * 4, blocksHeight * 4);
-
-		internal static Image<Rgba32> ImageFromRawBlocks(RawBlock4X4Rgba32[] blocks, int blocksWidth, int blocksHeight, int pixelWidth, int pixelHeight)
-		{
-			var output = new Image<Rgba32>(pixelWidth, pixelHeight);
-
-			if (!output.TryGetSinglePixelSpan(out var pixels))
-			{
-				throw new Exception("Cannot get pixel span.");
-			}
-
-			for (var y = 0; y < output.Height; y++)
-			{
-				for (var x = 0; x < output.Width; x++)
-				{
-					var blockIndexX = x >> 2;
-					var blockIndexY = y >> 2;
-					var blockInternalIndexX = x & 3;
-					var blockInternalIndexY = y & 3;
-
-					pixels[x + y * output.Width] =
-						blocks[blockIndexX + blockIndexY * blocksWidth]
-							[blockInternalIndexX, blockInternalIndexY];
 				}
 			}
 

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -125,5 +125,10 @@ namespace BCnEncoder.Shared
 
 			return blocksWidth * blocksHeight;
 		}
+		public static void CalculateNumOfBlocks(int pixelWidth, int pixelHeight, out int blocksWidth, out int blocksHeight)
+		{
+			blocksWidth = ((pixelWidth + 3) & ~3) >> 2;
+			blocksHeight = ((pixelHeight + 3) & ~3) >> 2;
+		}
 	}
 }

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -64,7 +64,7 @@ namespace BCnEncoder.Shared
 			{
 				for (var x = 0; x < image.Width; x++)
 				{
-					var color = span[x, y];
+					var color = span[y, x];
 
 					var blockIndexX = x >> 2;
 					var blockIndexY = y >> 2;

--- a/BCnEnc.Net/Shared/LinearClustering.cs
+++ b/BCnEnc.Net/Shared/LinearClustering.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
@@ -121,7 +120,7 @@ namespace BCnEncoder.Shared
 		/// the more spatial proximity is emphasized and the more compact the cluster,
 		/// M should be in range of 1 to 20.
 		/// </summary>
-		public static int[] ClusterPixels(ReadOnlySpan<Rgba32> pixels, int width, int height,
+		public static int[] ClusterPixels(ReadOnlySpan<ColorRgba32> pixels, int width, int height,
 			int clusters, float m = 10, int maxIterations = 10, bool enforceConnectivity = true)
 		{
 
@@ -292,7 +291,7 @@ namespace BCnEncoder.Shared
 			return clusterCenters;
 		}
 
-		private static LabXy[] ConvertToLabXy(ReadOnlySpan<Rgba32> pixels, int width, int height)
+		private static LabXy[] ConvertToLabXy(ReadOnlySpan<ColorRgba32> pixels, int width, int height)
 		{
 			var labXys = new LabXy[pixels.Length];
 			//Convert pixels to LabXy
@@ -302,7 +301,7 @@ namespace BCnEncoder.Shared
 				{
 					var i = x + y * width;
 					var lab = new ColorLab(pixels[i]);
-					labXys[i] = new LabXy()
+					labXys[i] = new LabXy
 					{
 						l = lab.l,
 						a = lab.a,

--- a/BCnEnc.Net/Shared/MipMapper.cs
+++ b/BCnEnc.Net/Shared/MipMapper.cs
@@ -12,7 +12,7 @@ namespace BCnEncoder.Shared
 		/// <param name="input">The original image to scale down.</param>
 		/// <param name="numMipMaps">The number of mipmaps to generate.</param>
 		/// <returns>Will generate as many mipmaps as possible until a mipmap of 1x1 is reached for <paramref name="numMipMaps"/> 0 or smaller.</returns>
-		public static Memory2D<ColorRgba32>[] GenerateMipChain(Memory2D<ColorRgba32> input, ref int numMipMaps)
+		public static ReadOnlyMemory2D<ColorRgba32>[] GenerateMipChain(ReadOnlyMemory2D<ColorRgba32> input, ref int numMipMaps)
 		{
 			if (!input.TryGetMemory(out var memory))
 			{
@@ -30,11 +30,11 @@ namespace BCnEncoder.Shared
 		/// <param name="height">The original image height.</param>
 		/// <param name="numMipMaps">The number of mipmaps to generate.</param>
 		/// <returns>Will generate as many mipmaps as possible until a mipmap of 1x1 is reached for <paramref name="numMipMaps"/> 0 or smaller.</returns>
-		public static Memory2D<ColorRgba32>[] GenerateMipChain(Memory<ColorRgba32> pixels, int width, int height, ref int numMipMaps)
+		public static ReadOnlyMemory2D<ColorRgba32>[] GenerateMipChain(ReadOnlyMemory<ColorRgba32> pixels, int width, int height, ref int numMipMaps)
 		{
 			var mipChainLength = CalculateMipChainLength(width, height, numMipMaps);
 
-			var result = new Memory2D<ColorRgba32>[mipChainLength];
+			var result = new ReadOnlyMemory2D<ColorRgba32>[mipChainLength];
 			result[0] = pixels.AsMemory2D(width, height);
 
 			// If only one mipmap was requested, return original image only

--- a/BCnEnc.Net/Shared/MipMapper.cs
+++ b/BCnEnc.Net/Shared/MipMapper.cs
@@ -113,19 +113,19 @@ namespace BCnEncoder.Shared
 			
 			var result = new ColorRgba32[newHeight, newWidth];
 			
-			int clampW(int x) => Math.Max(0, Math.Min(oldWidth - 1, x));
-			int clampH(int y) => Math.Max(0, Math.Min(oldHeight - 1, y));
+			int ClampW(int x) => Math.Max(0, Math.Min(oldWidth - 1, x));
+			int ClampH(int y) => Math.Max(0, Math.Min(oldHeight - 1, y));
 			
-			for (int y2 = 0; y2 < newHeight; y2++)
+			for (var y2 = 0; y2 < newHeight; y2++)
 			{
-				for (int x2 = 0; x2 < newWidth; x2++)
+				for (var x2 = 0; x2 < newWidth; x2++)
 				{
-					var xUL = pixelsRgba[clampH(y2 * 2), clampW(x2 * 2)].ToFloat();
-					var xUR = pixelsRgba[clampH(y2 * 2), clampW(x2 * 2 + 1)].ToFloat();
-					var xLL = pixelsRgba[clampH(y2 * 2 + 1), clampW(x2 * 2)].ToFloat();
-					var xLR = pixelsRgba[clampH(y2 * 2 + 1), clampW(x2 * 2 + 1)].ToFloat();
+					var ul = pixelsRgba[ClampH(y2 * 2), ClampW(x2 * 2)].ToFloat();
+					var ur = pixelsRgba[ClampH(y2 * 2), ClampW(x2 * 2 + 1)].ToFloat();
+					var ll = pixelsRgba[ClampH(y2 * 2 + 1), ClampW(x2 * 2)].ToFloat();
+					var lr = pixelsRgba[ClampH(y2 * 2 + 1), ClampW(x2 * 2 + 1)].ToFloat();
 
-					result[y2, x2] = ((xUL + xUR + xLL + xLR) / 4).ToRgba32();
+					result[y2, x2] = ((ul + ur + ll + lr) / 4).ToRgba32();
 				}
 			}
 

--- a/BCnEnc.Net/Shared/PcaVectors.cs
+++ b/BCnEnc.Net/Shared/PcaVectors.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Numerics;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
@@ -9,14 +8,14 @@ namespace BCnEncoder.Shared
 		private const int C565_5Mask = 0xF8;
 		private const int C565_6Mask = 0xFC;
 
-		private static void ConvertToVector4(ReadOnlySpan<Rgba32> colors, Span<Vector4> vectors)
+		private static void ConvertToVector4(ReadOnlySpan<ColorRgba32> colors, Span<Vector4> vectors)
 		{
 			for (var i = 0; i < colors.Length; i++)
 			{
-				vectors[i].X += colors[i].R / 255f;
-				vectors[i].Y += colors[i].G / 255f;
-				vectors[i].Z += colors[i].B / 255f;
-				vectors[i].W += colors[i].A / 255f;
+				vectors[i].X += colors[i].r / 255f;
+				vectors[i].Y += colors[i].g / 255f;
+				vectors[i].Z += colors[i].b / 255f;
+				vectors[i].W += colors[i].a / 255f;
 			}
 		}
 
@@ -110,7 +109,7 @@ namespace BCnEncoder.Shared
 			return lastDa;
 		}
 
-		public static void Create(Span<Rgba32> colors, out Vector3 mean, out Vector3 principalAxis)
+		public static void Create(Span<ColorRgba32> colors, out Vector3 mean, out Vector3 principalAxis)
 		{
 			Span<Vector4> vectors = stackalloc Vector4[colors.Length];
 			ConvertToVector4(colors, vectors);
@@ -130,7 +129,7 @@ namespace BCnEncoder.Shared
 
 		}
 
-		public static void CreateWithAlpha(Span<Rgba32> colors, out Vector4 mean, out Vector4 principalAxis)
+		public static void CreateWithAlpha(Span<ColorRgba32> colors, out Vector4 mean, out Vector4 principalAxis)
 		{
 			Span<Vector4> vectors = stackalloc Vector4[colors.Length];
 			ConvertToVector4(colors, vectors);
@@ -140,7 +139,7 @@ namespace BCnEncoder.Shared
 		}
 
 
-		public static void GetExtremePoints(Span<Rgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb24 min,
+		public static void GetExtremePoints(Span<ColorRgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb24 min,
 			out ColorRgb24 max)
 		{
 
@@ -149,7 +148,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < colors.Length; i++)
 			{
-				var colorVec = new Vector3(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f);
+				var colorVec = new Vector3(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f);
 
 				var v = colorVec - mean;
 				var d = Vector3.Dot(v, principalAxis);
@@ -180,7 +179,7 @@ namespace BCnEncoder.Shared
 			max = new ColorRgb24((byte)maxR, (byte)maxG, (byte)maxB);
 		}
 
-		public static void GetMinMaxColor565(Span<Rgba32> colors, Vector3 mean, Vector3 principalAxis, 
+		public static void GetMinMaxColor565(Span<ColorRgba32> colors, Vector3 mean, Vector3 principalAxis, 
 			out ColorRgb565 min, out ColorRgb565 max)
 		{
 
@@ -189,7 +188,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < colors.Length; i++)
 			{
-				var colorVec = new Vector3(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f);
+				var colorVec = new Vector3(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f);
 
 				var v = colorVec - mean;
 				var d = Vector3.Dot(v, principalAxis);
@@ -234,7 +233,7 @@ namespace BCnEncoder.Shared
 
 		}
 
-		public static void GetExtremePointsWithAlpha(Span<Rgba32> colors, Vector4 mean, Vector4 principalAxis, out Vector4 min,
+		public static void GetExtremePointsWithAlpha(Span<ColorRgba32> colors, Vector4 mean, Vector4 principalAxis, out Vector4 min,
 			out Vector4 max)
 		{
 
@@ -243,7 +242,7 @@ namespace BCnEncoder.Shared
 
 			for (var i = 0; i < colors.Length; i++)
 			{
-				var colorVec = new Vector4(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f, colors[i].A / 255f);
+				var colorVec = new Vector4(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f, colors[i].a / 255f);
 
 				var v = colorVec - mean;
 				var d = Vector4.Dot(v, principalAxis);
@@ -255,14 +254,14 @@ namespace BCnEncoder.Shared
 			max = mean + principalAxis * maxD;
 		}
 
-		public static void GetOptimizedEndpoints565(Span<Rgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb565 min, out ColorRgb565 max,
+		public static void GetOptimizedEndpoints565(Span<ColorRgba32> colors, Vector3 mean, Vector3 principalAxis, out ColorRgb565 min, out ColorRgb565 max,
 			float rWeight = 0.3f, float gWeight = 0.6f, float bWeight = 0.1f)
 		{
 			var length = colors.Length;
 			var vectorColors = new Vector3[length];
 			for (var i = 0; i < colors.Length; i++)
 			{
-				vectorColors[i] = new Vector3(colors[i].R / 255f, colors[i].G / 255f, colors[i].B / 255f);
+				vectorColors[i] = new Vector3(colors[i].r / 255f, colors[i].g / 255f, colors[i].b / 255f);
 			}
 
 			float minD = 0;

--- a/BCnEnc.Net/Shared/RawBlocks.cs
+++ b/BCnEnc.Net/Shared/RawBlocks.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {

--- a/BCnEnc.Net/Shared/RawBlocks.cs
+++ b/BCnEnc.Net/Shared/RawBlocks.cs
@@ -1,45 +1,51 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace BCnEncoder.Shared
 {
 
-	internal struct RawBlock4X4Rgba32 {
-		public Rgba32 p00, p10, p20, p30;
-		public Rgba32 p01, p11, p21, p31;
-		public Rgba32 p02, p12, p22, p32;
-		public Rgba32 p03, p13, p23, p33;
-		public Span<Rgba32> AsSpan => MemoryMarshal.CreateSpan(ref p00, 16);
+	public struct RawBlock4X4Rgba32
+	{
+		public ColorRgba32 p00, p10, p20, p30;
+		public ColorRgba32 p01, p11, p21, p31;
+		public ColorRgba32 p02, p12, p22, p32;
+		public ColorRgba32 p03, p13, p23, p33;
+		public Span<ColorRgba32> AsSpan => MemoryMarshal.CreateSpan(ref p00, 16);
 
-		public Rgba32 this[int x, int y] {
+		public ColorRgba32 this[int x, int y]
+		{
 			get => AsSpan[x + y * 4];
 			set => AsSpan[x + y * 4] = value;
 		}
 
-		public Rgba32 this[int index] {
+		public ColorRgba32 this[int index]
+		{
 			get => AsSpan[index];
 			set => AsSpan[index] = value;
 		}
 
-		public int CalculateError(RawBlock4X4Rgba32 other, bool useAlpha = false) {
+		public int CalculateError(RawBlock4X4Rgba32 other, bool useAlpha = false)
+		{
 			float error = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = pix1[i];
 				var col2 = pix2[i];
 
-				var re = col1.R - col2.R;
-				var ge = col1.G - col2.G;
-				var be = col1.B - col2.B;
+				var re = col1.r - col2.r;
+				var ge = col1.g - col2.g;
+				var be = col1.b - col2.b;
 
 				error += re * re;
 				error += ge * ge;
 				error += be * be;
 
-				if (useAlpha) {
-					var ae = col1.A - col2.A;
+				if (useAlpha)
+				{
+					var ae = col1.a - col2.a;
 					error += ae * ae * 4;
 				}
 			}
@@ -50,13 +56,15 @@ namespace BCnEncoder.Shared
 			return (int)error;
 		}
 
-		public float CalculateYCbCrError(RawBlock4X4Rgba32 other) {
+		public float CalculateYCbCrError(RawBlock4X4Rgba32 other)
+		{
 			float yError = 0;
 			float cbError = 0;
 			float crError = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = new ColorYCbCr(pix1[i]);
 				var col2 = new ColorYCbCr(pix2[i]);
 
@@ -74,14 +82,16 @@ namespace BCnEncoder.Shared
 			return error;
 		}
 
-		public float CalculateYCbCrAlphaError(RawBlock4X4Rgba32 other, float yMultiplier = 2, float alphaMultiplier = 1) {
+		public float CalculateYCbCrAlphaError(RawBlock4X4Rgba32 other, float yMultiplier = 2, float alphaMultiplier = 1)
+		{
 			float yError = 0;
 			float cbError = 0;
 			float crError = 0;
 			float alphaError = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = new ColorYCbCrAlpha(pix1[i]);
 				var col2 = new ColorYCbCrAlpha(pix2[i]);
 
@@ -100,45 +110,53 @@ namespace BCnEncoder.Shared
 			return error;
 		}
 
-		public RawBlock4X4Ycbcr ToRawBlockYcbcr() {
+		public RawBlock4X4Ycbcr ToRawBlockYcbcr()
+		{
 			var rawYcbcr = new RawBlock4X4Ycbcr();
 			var pixels = AsSpan;
 			var ycbcrPs = rawYcbcr.AsSpan;
-			for (var i = 0; i < pixels.Length; i++) {
+			for (var i = 0; i < pixels.Length; i++)
+			{
 				ycbcrPs[i] = new ColorYCbCr(pixels[i]);
 			}
 			return rawYcbcr;
 		}
 
-		public bool HasTransparentPixels() {
+		public bool HasTransparentPixels()
+		{
 			var pixels = AsSpan;
-			for (var i = 0; i < pixels.Length; i++) {
-				if (pixels[i].A < 255) return true;
+			for (var i = 0; i < pixels.Length; i++)
+			{
+				if (pixels[i].a < 255) return true;
 			}
 			return false;
 		}
 	}
 
 
-	internal struct RawBlock4X4Ycbcr {
+	public struct RawBlock4X4Ycbcr
+	{
 		public ColorYCbCr p00, p10, p20, p30;
 		public ColorYCbCr p01, p11, p21, p31;
 		public ColorYCbCr p02, p12, p22, p32;
 		public ColorYCbCr p03, p13, p23, p33;
 		public Span<ColorYCbCr> AsSpan => MemoryMarshal.CreateSpan(ref p00, 16);
 
-		public ColorYCbCr this[int x, int y] {
+		public ColorYCbCr this[int x, int y]
+		{
 			get => AsSpan[x + y * 4];
 			set => AsSpan[x + y * 4] = value;
 		}
 
-		public float CalculateError(RawBlock4X4Rgba32 other) {
+		public float CalculateError(RawBlock4X4Rgba32 other)
+		{
 			float yError = 0;
 			float cbError = 0;
 			float crError = 0;
 			var pix1 = AsSpan;
 			var pix2 = other.AsSpan;
-			for (var i = 0; i < pix1.Length; i++) {
+			for (var i = 0; i < pix1.Length; i++)
+			{
 				var col1 = pix1[i];
 				var col2 = new ColorYCbCr(pix2[i]);
 

--- a/BCnEnc.Net/Shared/RawBlocks.cs
+++ b/BCnEnc.Net/Shared/RawBlocks.cs
@@ -24,7 +24,7 @@ namespace BCnEncoder.Shared
 			set => AsSpan[index] = value;
 		}
 
-		public int CalculateError(RawBlock4X4Rgba32 other, bool useAlpha = false)
+		internal int CalculateError(RawBlock4X4Rgba32 other, bool useAlpha = false)
 		{
 			float error = 0;
 			var pix1 = AsSpan;
@@ -55,7 +55,7 @@ namespace BCnEncoder.Shared
 			return (int)error;
 		}
 
-		public float CalculateYCbCrError(RawBlock4X4Rgba32 other)
+		internal float CalculateYCbCrError(RawBlock4X4Rgba32 other)
 		{
 			float yError = 0;
 			float cbError = 0;
@@ -81,7 +81,7 @@ namespace BCnEncoder.Shared
 			return error;
 		}
 
-		public float CalculateYCbCrAlphaError(RawBlock4X4Rgba32 other, float yMultiplier = 2, float alphaMultiplier = 1)
+		internal float CalculateYCbCrAlphaError(RawBlock4X4Rgba32 other, float yMultiplier = 2, float alphaMultiplier = 1)
 		{
 			float yError = 0;
 			float cbError = 0;
@@ -109,7 +109,7 @@ namespace BCnEncoder.Shared
 			return error;
 		}
 
-		public RawBlock4X4Ycbcr ToRawBlockYcbcr()
+		internal RawBlock4X4Ycbcr ToRawBlockYcbcr()
 		{
 			var rawYcbcr = new RawBlock4X4Ycbcr();
 			var pixels = AsSpan;
@@ -133,7 +133,7 @@ namespace BCnEncoder.Shared
 	}
 
 
-	public struct RawBlock4X4Ycbcr
+	internal struct RawBlock4X4Ycbcr
 	{
 		public ColorYCbCr p00, p10, p20, p30;
 		public ColorYCbCr p01, p11, p21, p31;

--- a/BCnEnc.Net/Shared/RgbBoundingBox.cs
+++ b/BCnEnc.Net/Shared/RgbBoundingBox.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using SixLabors.ImageSharp.PixelFormats;
+using System;
 
 namespace BCnEncoder.Shared
 {
@@ -11,7 +10,7 @@ namespace BCnEncoder.Shared
 	internal static class RgbBoundingBox
 	{
 
-		public static void Create565(ReadOnlySpan<Rgba32> colors, out ColorRgb565 min, out ColorRgb565 max)
+		public static void Create565(ReadOnlySpan<ColorRgba32> colors, out ColorRgb565 min, out ColorRgb565 max)
 		{
 			const int colorInsetShift = 4;
 			const int c5655Mask = 0xF8;
@@ -28,13 +27,13 @@ namespace BCnEncoder.Shared
 			{
 				var c = colors[i];
 
-				if (c.R < minR) minR = c.R;
-				if (c.G < minG) minG = c.G;
-				if (c.B < minB) minB = c.B;
+				if (c.r < minR) minR = c.r;
+				if (c.g < minG) minG = c.g;
+				if (c.b < minB) minB = c.b;
 
-				if (c.R > maxR) maxR = c.R;
-				if (c.G > maxG) maxG = c.G;
-				if (c.B > maxB) maxB = c.B;
+				if (c.r > maxR) maxR = c.r;
+				if (c.g > maxG) maxG = c.g;
+				if (c.b > maxB) maxB = c.b;
 			}
 
 			var insetR = (maxR - minR) >> colorInsetShift;
@@ -71,7 +70,7 @@ namespace BCnEncoder.Shared
 			max = new ColorRgb565((byte)maxR, (byte)maxG, (byte)maxB);
 		}
 
-		public static void Create565AlphaCutoff(ReadOnlySpan<Rgba32> colors, out ColorRgb565 min, out ColorRgb565 max, int alphaCutoff = 128)
+		public static void Create565AlphaCutoff(ReadOnlySpan<ColorRgba32> colors, out ColorRgb565 min, out ColorRgb565 max, int alphaCutoff = 128)
 		{
 			const int colorInsetShift = 4;
 			const int c5655Mask = 0xF8;
@@ -87,14 +86,14 @@ namespace BCnEncoder.Shared
 			for (var i = 0; i < colors.Length; i++)
 			{
 				var c = colors[i];
-				if (c.A < alphaCutoff) continue;
-				if (c.R < minR) minR = c.R;
-				if (c.G < minG) minG = c.G;
-				if (c.B < minB) minB = c.B;
+				if (c.a < alphaCutoff) continue;
+				if (c.r < minR) minR = c.r;
+				if (c.g < minG) minG = c.g;
+				if (c.b < minB) minB = c.b;
 
-				if (c.R > maxR) maxR = c.R;
-				if (c.G > maxG) maxG = c.G;
-				if (c.B > maxB) maxB = c.B;
+				if (c.r > maxR) maxR = c.r;
+				if (c.g > maxG) maxG = c.g;
+				if (c.b > maxB) maxB = c.b;
 			}
 
 			var insetR = (maxR - minR) >> colorInsetShift;
@@ -129,7 +128,7 @@ namespace BCnEncoder.Shared
 			max = new ColorRgb565((byte)maxR, (byte)maxG, (byte)maxB);
 		}
 
-		public static void Create565A(ReadOnlySpan<Rgba32> colors, out ColorRgb565 min, out ColorRgb565 max, out byte minAlpha, out byte maxAlpha)
+		public static void Create565A(ReadOnlySpan<ColorRgba32> colors, out ColorRgb565 min, out ColorRgb565 max, out byte minAlpha, out byte maxAlpha)
 		{
 			const int colorInsetShift = 4;
 			const int alphaInsetShift = 5;
@@ -148,15 +147,15 @@ namespace BCnEncoder.Shared
 			for (var i = 0; i < colors.Length; i++)
 			{
 				var c = colors[i];
-				if (c.R < minR) minR = c.R;
-				if (c.G < minG) minG = c.G;
-				if (c.B < minB) minB = c.B;
-				if (c.A < minA) minA = c.A;
+				if (c.r < minR) minR = c.r;
+				if (c.g < minG) minG = c.g;
+				if (c.b < minB) minB = c.b;
+				if (c.a < minA) minA = c.a;
 
-				if (c.R > maxR) maxR = c.R;
-				if (c.G > maxG) maxG = c.G;
-				if (c.B > maxB) maxB = c.B;
-				if (c.A > maxA) maxA = c.A;
+				if (c.r > maxR) maxR = c.r;
+				if (c.g > maxG) maxG = c.g;
+				if (c.b > maxB) maxB = c.b;
+				if (c.a > maxA) maxA = c.a;
 			}
 
 

--- a/BCnEncTests/AtcTests.cs
+++ b/BCnEncTests/AtcTests.cs
@@ -3,6 +3,7 @@ using BCnEncoder.Encoder;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using Xunit;
+using BCnEncoder.NET.ImageSharp;
 
 namespace BCnEncTests
 {
@@ -18,7 +19,7 @@ namespace BCnEncTests
 
 			// Act
 			var ktx = encoder.EncodeToKtx(original);
-			var image = decoder.Decode(ktx);
+			var image = decoder.DecodeToImageRgba32(ktx);
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
@@ -34,7 +35,7 @@ namespace BCnEncTests
 
 			// Act
 			var dds = encoder.EncodeToDds(original);
-			var image = decoder.Decode(dds);
+			var image = decoder.DecodeToImageRgba32(dds);
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
@@ -50,7 +51,7 @@ namespace BCnEncTests
 
 			// Act
 			var ktx = encoder.EncodeToKtx(original);
-			var image = decoder.Decode(ktx);
+			var image = decoder.DecodeToImageRgba32(ktx);
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
@@ -66,7 +67,7 @@ namespace BCnEncTests
 
 			// Act
 			var dds = encoder.EncodeToDds(original);
-			var image = decoder.Decode(dds);
+			var image = decoder.DecodeToImageRgba32(dds);
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
@@ -82,7 +83,7 @@ namespace BCnEncTests
 
 			// Act
 			var ktx = encoder.EncodeToKtx(original);
-			var image = decoder.Decode(ktx);
+			var image = decoder.DecodeToImageRgba32(ktx);
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
@@ -98,7 +99,7 @@ namespace BCnEncTests
 
 			// Act
 			var dds = encoder.EncodeToDds(original);
-			var image = decoder.Decode(dds);
+			var image = decoder.DecodeToImageRgba32(dds);
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);

--- a/BCnEncTests/BC1Tests.cs
+++ b/BCnEncTests/BC1Tests.cs
@@ -1,6 +1,7 @@
 using BCnEncoder.Shared;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
+using BCnEncoder.NET.ImageSharp;
 
 namespace BCnEncTests
 {
@@ -37,25 +38,25 @@ namespace BCnEncTests
 			block[15] = 0;
 
 			var raw = block.Decode(false);
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p00);
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p10);
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p20);
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p30);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p00);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p10);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p20);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p30);
 
-			Assert.Equal(new Rgba32(85, 85, 85), raw.p01);
-			Assert.Equal(new Rgba32(85, 85, 85), raw.p11);
-			Assert.Equal(new Rgba32(85, 85, 85), raw.p21);
-			Assert.Equal(new Rgba32(85, 85, 85), raw.p31);
+			Assert.Equal(new ColorRgba32(85, 85, 85), raw.p01);
+			Assert.Equal(new ColorRgba32(85, 85, 85), raw.p11);
+			Assert.Equal(new ColorRgba32(85, 85, 85), raw.p21);
+			Assert.Equal(new ColorRgba32(85, 85, 85), raw.p31);
 
-			Assert.Equal(new Rgba32(170, 170, 170), raw.p02);
-			Assert.Equal(new Rgba32(170, 170, 170), raw.p12);
-			Assert.Equal(new Rgba32(170, 170, 170), raw.p22);
-			Assert.Equal(new Rgba32(170, 170, 170), raw.p32);
+			Assert.Equal(new ColorRgba32(170, 170, 170), raw.p02);
+			Assert.Equal(new ColorRgba32(170, 170, 170), raw.p12);
+			Assert.Equal(new ColorRgba32(170, 170, 170), raw.p22);
+			Assert.Equal(new ColorRgba32(170, 170, 170), raw.p32);
 
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p03);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p13);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p23);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p33);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p03);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p13);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p23);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p33);
 		}
 
 		[Fact]
@@ -88,25 +89,25 @@ namespace BCnEncTests
 			block[15] = 1;
 
 			var raw = block.Decode(false);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p00);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p10);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p20);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p30);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p00);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p10);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p20);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p30);
 
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p01);
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p11);
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p21);
-			Assert.Equal(new Rgba32(0, 0, 0), raw.p31);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p01);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p11);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p21);
+			Assert.Equal(new ColorRgba32(0, 0, 0), raw.p31);
 
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p02);
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p12);
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p22);
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p32);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p02);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p12);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p22);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p32);
 
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p03);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p13);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p23);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p33);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p03);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p13);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p23);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p33);
 		}
 
 		[Fact]
@@ -139,25 +140,25 @@ namespace BCnEncTests
 			block[15] = 1;
 
 			var raw = block.Decode(true);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p00);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p10);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p20);
-			Assert.Equal(new Rgba32(206, 203, 206), raw.p30);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p00);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p10);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p20);
+			Assert.Equal(new ColorRgba32(206, 203, 206), raw.p30);
 
-			Assert.Equal(new Rgba32(0,0,0,0), raw.p01);
-			Assert.Equal(new Rgba32(0,0,0,0), raw.p11);
-			Assert.Equal(new Rgba32(0,0,0,0), raw.p21);
-			Assert.Equal(new Rgba32(0,0,0,0), raw.p31);
+			Assert.Equal(new ColorRgba32(0,0,0,0), raw.p01);
+			Assert.Equal(new ColorRgba32(0,0,0,0), raw.p11);
+			Assert.Equal(new ColorRgba32(0,0,0,0), raw.p21);
+			Assert.Equal(new ColorRgba32(0,0,0,0), raw.p31);
 
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p02);
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p12);
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p22);
-			Assert.Equal(new Rgba32(230, 229, 230), raw.p32);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p02);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p12);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p22);
+			Assert.Equal(new ColorRgba32(230, 229, 230), raw.p32);
 
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p03);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p13);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p23);
-			Assert.Equal(new Rgba32(255, 255, 255), raw.p33);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p03);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p13);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p23);
+			Assert.Equal(new ColorRgba32(255, 255, 255), raw.p33);
 		}
 	}
 }

--- a/BCnEncTests/BCnEncTests.csproj
+++ b/BCnEncTests/BCnEncTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BCnEnc.Net\BCnEncoder.csproj" />
+    <ProjectReference Include="..\BCnEncoder.NET.ImageSharp\BCnEncoder.NET.ImageSharp.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BCnEncTests/Bc5Tests.cs
+++ b/BCnEncTests/Bc5Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using BCnEncoder.Decoder;
+using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using SixLabors.ImageSharp;
@@ -38,7 +39,7 @@ namespace BCnEncTests
 		public void Bc5DdsDecode()
 		{
 			var reference = ImageLoader.TestDecodingBc5Reference;
-			var decoded = new BcDecoder().Decode(DdsLoader.TestDecompressBc5);
+			var decoded = new BcDecoder().DecodeToImageRgba32(DdsLoader.TestDecompressBc5);
 
 			reference.TryGetSinglePixelSpan(out var refSpan);
 			decoded.TryGetSinglePixelSpan(out var decSpan);
@@ -62,22 +63,22 @@ namespace BCnEncTests
 			
 			var referenceBlock = new RawBlock4X4Rgba32
 			{
-				p00 = new Rgba32(13, 53, 0, 255),
-				p01 = new Rgba32(136, 238, 0, 255),
-				p02 = new Rgba32(255, 212, 0, 255),
-				p03 = new Rgba32(167, 238, 0, 255),
-				p10 = new Rgba32(13, 53, 0, 255),
-				p11 = new Rgba32(136, 238, 0, 255),
-				p12 = new Rgba32(167, 238, 0, 255),
-				p13 = new Rgba32(75, 185, 0, 255),
-				p20 = new Rgba32(255, 212, 0, 255),
-				p21 = new Rgba32(167, 238, 0, 255),
-				p22 = new Rgba32(13, 53, 0, 255),
-				p23 = new Rgba32(75, 159, 0, 255),
-				p30 = new Rgba32(167, 238, 0, 255),
-				p31 = new Rgba32(75, 185, 0, 255),
-				p32 = new Rgba32(13, 53, 0, 255),
-				p33 = new Rgba32(75, 159, 0, 255)
+				p00 = new ColorRgba32(13, 53, 0, 255),
+				p01 = new ColorRgba32(136, 238, 0, 255),
+				p02 = new ColorRgba32(255, 212, 0, 255),
+				p03 = new ColorRgba32(167, 238, 0, 255),
+				p10 = new ColorRgba32(13, 53, 0, 255),
+				p11 = new ColorRgba32(136, 238, 0, 255),
+				p12 = new ColorRgba32(167, 238, 0, 255),
+				p13 = new ColorRgba32(75, 185, 0, 255),
+				p20 = new ColorRgba32(255, 212, 0, 255),
+				p21 = new ColorRgba32(167, 238, 0, 255),
+				p22 = new ColorRgba32(13, 53, 0, 255),
+				p23 = new ColorRgba32(75, 159, 0, 255),
+				p30 = new ColorRgba32(167, 238, 0, 255),
+				p31 = new ColorRgba32(75, 185, 0, 255),
+				p32 = new ColorRgba32(13, 53, 0, 255),
+				p33 = new ColorRgba32(75, 159, 0, 255)
 			};
 
 			var decodedBlock = block.Decode();

--- a/BCnEncTests/Bc5Tests.cs
+++ b/BCnEncTests/Bc5Tests.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using BCnEncoder.Decoder;
 using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace BCnEncTests
@@ -57,10 +51,10 @@ namespace BCnEncTests
 		{
 			var block = new Bc5Block()
 			{
-				greenBlock = new Bc4ComponentBlock(){componentBlock = 0x91824260008935ee},
+				greenBlock = new Bc4ComponentBlock() { componentBlock = 0x91824260008935ee },
 				redBlock = new Bc4ComponentBlock() { componentBlock = 0x6d900f66d3c0a70d }
 			};
-			
+
 			var referenceBlock = new RawBlock4X4Rgba32
 			{
 				p00 = new ColorRgba32(13, 53, 0, 255),

--- a/BCnEncTests/Bc7BlockTests.cs
+++ b/BCnEncTests/Bc7BlockTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using Xunit;
 
 namespace BCnEncTests

--- a/BCnEncTests/BgraTests.cs
+++ b/BCnEncTests/BgraTests.cs
@@ -1,5 +1,6 @@
 using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
+using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using Xunit;
@@ -18,7 +19,9 @@ namespace BCnEncTests
 
 			// Act
 			var dds = encoder.EncodeToDds(original);
-			var image = decoder.Decode(dds);
+			var image = decoder.DecodeToImageRgba32(dds);
+
+			
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
@@ -34,7 +37,39 @@ namespace BCnEncTests
 
 			// Act
 			var dds = encoder.EncodeToDds(original);
-			var image = decoder.Decode(dds);
+			var image = decoder.DecodeToImageRgba32(dds);
+
+			// Assert
+			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
+		}
+
+		[Fact]
+		public void BgraKtxDecode()
+		{
+			// Arrange
+			var decoder = new BcDecoder();
+			var encoder = new BcEncoder(CompressionFormat.Bgra);
+			var original = ImageLoader.TestLenna;
+
+			// Act
+			var ktx = encoder.EncodeToKtx(original);
+			var image = decoder.DecodeToImageRgba32(ktx);
+
+			// Assert
+			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
+		}
+
+		[Fact]
+		public void BgraAlphaKtxDecode()
+		{
+			// Arrange
+			var decoder = new BcDecoder();
+			var encoder = new BcEncoder(CompressionFormat.Bgra);
+			var original = ImageLoader.TestAlphaGradient1;
+
+			// Act
+			var ktx = encoder.EncodeToKtx(original);
+			var image = decoder.DecodeToImageRgba32(ktx);
 
 			// Assert
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);

--- a/BCnEncTests/ClusterTests.cs
+++ b/BCnEncTests/ClusterTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace BCnEncTests
@@ -14,10 +16,12 @@ namespace BCnEncTests
 		{
 			var testImage = ImageLoader.TestBlur1;
 
-			if (!testImage.TryGetSinglePixelSpan(out var pixels))
+			if (!testImage.TryGetSinglePixelSpan(out var pix))
 			{
 				throw new Exception("Cannot get pixel span.");
 			}
+
+			var pixels = MemoryMarshal.Cast<Rgba32, ColorRgba32>(pix).ToArray();
 
 			var numClusters = (testImage.Width / 32) * (testImage.Height / 32);
 			var clusters = LinearClustering.ClusterPixels(pixels, testImage.Width, testImage.Height, numClusters, 10, 10);
@@ -38,7 +42,7 @@ namespace BCnEncTests
 
 			for (var i = 0; i < pixels.Length; i++)
 			{
-				pixels[i] = pixC[clusters[i]].ToRgba32();
+				pixels[i] = pixC[clusters[i]].ToColorRgba32();
 			}
 
 			using var fs = File.OpenWrite("test_cluster.png");

--- a/BCnEncTests/DdsReadTests.cs
+++ b/BCnEncTests/DdsReadTests.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using BCnEncoder.Decoder;
+using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using BCnEncTests.Support;
 using SixLabors.ImageSharp;
 using Xunit;
@@ -39,7 +41,7 @@ namespace BCnEncTests
 			using var fs = File.OpenRead(DdsLoader.TestDecompressBc1Name);
 
 			var decoder = new BcDecoder();
-			var images = decoder.DecodeAllMipMaps(fs);
+			var images = decoder.DecodeAllMipMapsToImageRgba32(fs);
 
 			for (var i = 0; i < images.Length; i++)
 			{

--- a/BCnEncTests/DecodingAsyncTests.cs
+++ b/BCnEncTests/DecodingAsyncTests.cs
@@ -49,7 +49,7 @@ namespace BCnEncTests
 
 			var file = encoder.EncodeToKtx(original);
 			
-			MemoryStream ms = new MemoryStream(file.MipMaps[0].Faces[0].Data);
+			var ms = new MemoryStream(file.MipMaps[0].Faces[0].Data);
 			
 			var image = await decoder.DecodeRawToImageRgba32Async(ms,
 				(int) file.MipMaps[0].Width, (int) file.MipMaps[0].Height, CompressionFormat.Bc1);

--- a/BCnEncTests/DecodingAsyncTests.cs
+++ b/BCnEncTests/DecodingAsyncTests.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
+using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using Xunit;
@@ -17,7 +19,7 @@ namespace BCnEncTests
 			var original = ImageLoader.TestGradient1;
 
 			var file = encoder.EncodeToKtx(original);
-			var image = await decoder.DecodeAsync(file);
+			var image = await decoder.DecodeToImageRgba32Async(file);
 
 			TestHelper.AssertImagesEqual(original, image,encoder.OutputOptions.Quality);
 			image.Dispose();
@@ -31,7 +33,7 @@ namespace BCnEncTests
 			var original = ImageLoader.TestGradient1;
 
 			var file = encoder.EncodeToKtx(original);
-			var images = await decoder.DecodeAllMipMapsAsync(file);
+			var images = await decoder.DecodeAllMipMapsToImageRgba32Async(file);
 
 			TestHelper.AssertImagesEqual(original, images[0], encoder.OutputOptions.Quality);
 			foreach(var img in images)
@@ -46,8 +48,11 @@ namespace BCnEncTests
 			var original = ImageLoader.TestGradient1;
 
 			var file = encoder.EncodeToKtx(original);
-			var image = await decoder.DecodeRawAsync(file.MipMaps[0].Faces[0].Data, CompressionFormat.Bc1,
-				(int) file.MipMaps[0].Width, (int) file.MipMaps[0].Height);
+			
+			MemoryStream ms = new MemoryStream(file.MipMaps[0].Faces[0].Data);
+			
+			var image = await decoder.DecodeRawToImageRgba32Async(ms,
+				(int) file.MipMaps[0].Width, (int) file.MipMaps[0].Height, CompressionFormat.Bc1);
 
 			TestHelper.AssertImagesEqual(original, image, encoder.OutputOptions.Quality);
 			image.Dispose();

--- a/BCnEncTests/EncodeByteOrderTests.cs
+++ b/BCnEncTests/EncodeByteOrderTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using BCnEncoder.Decoder;
+using BCnEncoder.Encoder;
+using BCnEncoder.NET.ImageSharp;
+using BCnEncoder.Shared;
+using BCnEncTests.Support;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace BCnEncTests
+{
+	public class EncodeByteOrderTests
+	{
+
+		private void EncodeByteOrderTest<T>(PixelFormat pixelFormat) where T : unmanaged, IPixel<T>
+		{
+			var imageOrig = ImageLoader.TestAlpha1;
+			var testImage = imageOrig.CloneAs<T>();
+			
+			var pixels = testImage.GetPixelMemoryGroup()[0];
+			var bytes = MemoryMarshal.AsBytes(pixels.Span);
+
+			var encoder = new BcEncoder(CompressionFormat.Bc3);
+			var decoder = new BcDecoder();
+
+			using var ms = new MemoryStream();
+
+			encoder.EncodeToStream(bytes, testImage.Width, testImage.Height, pixelFormat, ms);
+
+			ms.Position = 0;
+
+			var decoded = decoder.DecodeToImageRgba32(ms);
+
+			bool hasNoAlpha = pixelFormat == PixelFormat.Rgb24 || pixelFormat == PixelFormat.Bgr24;
+
+			TestHelper.AssertImagesEqual(imageOrig, decoded, encoder.OutputOptions.Quality,
+				!hasNoAlpha);
+		}
+
+		[Fact]
+		public void EncodeByteOrderBgra()
+		{
+			EncodeByteOrderTest<Bgra32>(PixelFormat.Bgra32);
+		}
+
+		[Fact]
+		public void EncodeByteOrderBgr()
+		{
+			EncodeByteOrderTest<Bgr24>(PixelFormat.Bgr24);
+		}
+
+		[Fact]
+		public void EncodeByteOrderArgb()
+		{
+			EncodeByteOrderTest<Argb32>(PixelFormat.Argb32);
+		}
+
+		[Fact]
+		public void EncodeByteOrderRgba()
+		{
+			EncodeByteOrderTest<Rgba32>(PixelFormat.Rgba32);
+		}
+
+		[Fact]
+		public void EncodeByteOrderRgb24()
+		{
+			EncodeByteOrderTest<Rgb24>(PixelFormat.Rgb24);
+		}
+	}
+}

--- a/BCnEncTests/EncodingAsyncTest.cs
+++ b/BCnEncTests/EncodingAsyncTest.cs
@@ -1,5 +1,6 @@
 using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
+using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using SixLabors.ImageSharp;
@@ -27,7 +28,7 @@ namespace BCnEncTests
 		public async void EncodeToDdsAsync()
 		{
 			var file = await encoder.EncodeToDdsAsync(originalImage);
-			var image = decoder.Decode(file);
+			var image = decoder.DecodeToImageRgba32(file);
 
 			TestHelper.AssertImagesEqual(originalImage, image, encoder.OutputOptions.Quality);
 			image.Dispose();
@@ -37,7 +38,7 @@ namespace BCnEncTests
 		public async void EncodeToKtxAsync()
 		{
 			var file = await encoder.EncodeToKtxAsync(originalImage);
-			var image = decoder.Decode(file);
+			var image = decoder.DecodeToImageRgba32(file);
 
 			TestHelper.AssertImagesEqual(originalImage, image, encoder.OutputOptions.Quality);
 			image.Dispose();
@@ -51,7 +52,7 @@ namespace BCnEncTests
 
 			for (var i = 0; i < 6; i++)
 			{
-				var image = decoder.DecodeRaw(file.Faces[i].MipMaps[0].Data, CompressionFormat.Bc1, (int)file.Faces[i].Width, (int)file.Faces[i].Height);
+				var image = decoder.DecodeRawToImageRgba32(file.Faces[i].MipMaps[0].Data, (int)file.Faces[i].Width, (int)file.Faces[i].Height, CompressionFormat.Bc1);
 
 				TestHelper.AssertImagesEqual(originalCubeMap[i], image, encoder.OutputOptions.Quality);
 				image.Dispose();
@@ -66,7 +67,7 @@ namespace BCnEncTests
 
 			for (var i = 0; i < 6; i++)
 			{
-				var image = decoder.DecodeRaw(file.MipMaps[0].Faces[i].Data, CompressionFormat.Bc1, (int)file.MipMaps[0].Faces[i].Width, (int)file.MipMaps[0].Faces[i].Height);
+				var image = decoder.DecodeRawToImageRgba32(file.MipMaps[0].Faces[i].Data, (int)file.MipMaps[0].Faces[i].Width, (int)file.MipMaps[0].Faces[i].Height, CompressionFormat.Bc1);
 
 				TestHelper.AssertImagesEqual(originalCubeMap[i], image, encoder.OutputOptions.Quality);
 				image.Dispose();
@@ -77,7 +78,7 @@ namespace BCnEncTests
 		public async void EncodeToRawBytesAsync()
 		{
 			var data = await encoder.EncodeToRawBytesAsync(originalImage);
-			var image = decoder.DecodeRaw(data[0], CompressionFormat.Bc1, originalImage.Width, originalImage.Height);
+			var image = decoder.DecodeRawToImageRgba32(data[0], originalImage.Width, originalImage.Height, CompressionFormat.Bc1);
 
 			TestHelper.AssertImagesEqual(originalImage, image, encoder.OutputOptions.Quality);
 			image.Dispose();

--- a/BCnEncTests/EncodingTest.cs
+++ b/BCnEncTests/EncodingTest.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using BCnEncoder.Encoder;
+using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using Xunit;
@@ -494,7 +495,7 @@ namespace BCnEncTests
 			encoder.OutputOptions.Format = CompressionFormat.Bc1;
 
 			using var fs = File.OpenWrite(filename);
-			encoder.EncodeCubeMap(images[0], images[1], images[2], images[3], images[4], images[5], fs);
+			encoder.EncodeCubeMapToStream(images[0], images[1], images[2], images[3], images[4], images[5], fs);
 		}
 	}
 }

--- a/BCnEncTests/RawTests.cs
+++ b/BCnEncTests/RawTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
+using BCnEncoder.NET.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
 using SixLabors.ImageSharp.Processing;
@@ -21,7 +22,7 @@ namespace BCnEncTests
 			};
 
 			var encodedRawBytes = encoder.EncodeToRawBytes(inputImage);
-			var decodedImage = decoder.DecodeRaw(encodedRawBytes[0], CompressionFormat.Bc1, inputImage.Width, inputImage.Height);
+			var decodedImage = decoder.DecodeRawToImageRgba32(encodedRawBytes[0], inputImage.Width, inputImage.Height, CompressionFormat.Bc1);
 
 			ImageLoader.TestGradient1.TryGetSinglePixelSpan(out var originalPixels);
 			decodedImage.TryGetSinglePixelSpan(out var decodedPixels);
@@ -45,7 +46,7 @@ namespace BCnEncTests
 
 			Assert.Equal(0, ms.Position);
 
-			var decodedImage = decoder.DecodeRaw(ms, CompressionFormat.Bc1, inputImage.Width, inputImage.Height);
+			var decodedImage = decoder.DecodeRawToImageRgba32(ms, inputImage.Width, inputImage.Height, CompressionFormat.Bc1);
 
 			inputImage.TryGetSinglePixelSpan(out var originalPixels);
 			decodedImage.TryGetSinglePixelSpan(out var decodedPixels);
@@ -89,7 +90,7 @@ namespace BCnEncTests
 				encoder.CalculateMipMapSize(inputImage, i, out var mipWidth, out var mipHeight);
 				using var resized = inputImage.Clone(x => x.Resize(mipWidth, mipHeight));
 
-				var decodedImage = decoder.DecodeRaw(ms, CompressionFormat.Bc1, mipWidth, mipHeight);
+				var decodedImage = decoder.DecodeRawToImageRgba32(ms, mipWidth, mipHeight, CompressionFormat.Bc1);
 				resized.TryGetSinglePixelSpan(out var originalPixels);
 				decodedImage.TryGetSinglePixelSpan(out var decodedPixels);
 

--- a/BCnEncTests/SingleBlockTests.cs
+++ b/BCnEncTests/SingleBlockTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using BCnEncoder.Decoder;
+using BCnEncoder.Encoder;
+using BCnEncoder.Shared;
+using BCnEncTests.Support;
+using Microsoft.Toolkit.HighPerformance.Extensions;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace BCnEncTests
+{
+	public class SingleBlockTests
+	{
+
+		[Theory]
+		[InlineData(CompressionFormat.Bc1, CompressionQuality.Fast)]
+		[InlineData(CompressionFormat.Bc1, CompressionQuality.Balanced)]
+		[InlineData(CompressionFormat.Bc3, CompressionQuality.Fast)]
+		[InlineData(CompressionFormat.Bc3, CompressionQuality.Balanced)]
+		[InlineData(CompressionFormat.Bc7, CompressionQuality.Fast)]
+		public void SingleBlockEncodeDecodeStream(CompressionFormat format, CompressionQuality quality)
+		{
+			var testImage = ImageLoader.TestAlpha1;
+
+			var encoder = new BcEncoder()
+			{
+				OutputOptions =
+				{
+					Format = format,
+					Quality = quality
+				}
+			};
+			
+			var pixels = testImage.GetPixelMemoryGroup()[0];
+			var colors = MemoryMarshal.Cast<Rgba32, ColorRgba32>(pixels.Span)
+				.AsSpan2D(testImage.Height, testImage.Width);
+
+			var ms = new MemoryStream(); 
+			
+			for (var y = 0; y < testImage.Height; y+=4)
+			{
+				for (var x = 0; x < testImage.Width; x+=4)
+				{
+					encoder.EncodeBlock(colors.Slice(y, x, 4, 4), ms);
+				}
+			}
+
+			Assert.Equal(ms.Position, encoder.GetBlockSize() * encoder.GetBlockCount(testImage.Width, testImage.Height));
+
+			ms.Position = 0;
+
+			var decoder = new BcDecoder();
+
+			var decoded = new ColorRgba32[testImage.Height, testImage.Width];
+
+			for (var y = 0; y < testImage.Height; y += 4)
+			{
+				for (var x = 0; x < testImage.Width; x += 4)
+				{
+					decoder.DecodeBlock(ms, format,
+						decoded.AsSpan2D().Slice(y, x, 4, 4));
+				}
+			}
+
+			colors.TryGetSpan(out var oPixels);
+			decoded.AsSpan2D().TryGetSpan(out var dPixels);
+			var psnr = ImageQuality.PeakSignalToNoiseRatio(oPixels, dPixels,
+				format != CompressionFormat.Bc1);
+
+			TestHelper.AssertPSNR(psnr, quality);
+		}
+
+		[Theory]
+		[InlineData(CompressionFormat.Bc1, CompressionQuality.Fast)]
+		[InlineData(CompressionFormat.Bc1, CompressionQuality.Balanced)]
+		[InlineData(CompressionFormat.Bc3, CompressionQuality.Fast)]
+		[InlineData(CompressionFormat.Bc3, CompressionQuality.Balanced)]
+		[InlineData(CompressionFormat.Bc7, CompressionQuality.Fast)]
+		public void SingleBlockEncodeDecode(CompressionFormat format, CompressionQuality quality)
+		{
+			var testImage = ImageLoader.TestAlpha1;
+
+			var encoder = new BcEncoder()
+			{
+				OutputOptions =
+				{
+					Format = format,
+					Quality = quality
+				}
+			};
+
+			var pixels = testImage.GetPixelMemoryGroup()[0];
+			var colors = MemoryMarshal.Cast<Rgba32, ColorRgba32>(pixels.Span)
+				.AsSpan2D(testImage.Height, testImage.Width);
+
+			Span<byte> buffer = new byte[encoder.GetBlockSize() * encoder.GetBlockCount(testImage.Width, testImage.Height)];
+
+			var blockIndex = 0;
+			for (var y = 0; y < testImage.Height; y += 4)
+			{
+				for (var x = 0; x < testImage.Width; x += 4)
+				{
+					var bytes = encoder.EncodeBlock(colors.Slice(y, x, 4, 4));
+					bytes.CopyTo(buffer.Slice(blockIndex * encoder.GetBlockSize()));
+					blockIndex++;
+				}
+			}
+			
+			var decoder = new BcDecoder();
+
+			var decoded = new ColorRgba32[testImage.Height, testImage.Width];
+
+			blockIndex = 0;
+			for (var y = 0; y < testImage.Height; y += 4)
+			{
+				for (var x = 0; x < testImage.Width; x += 4)
+				{
+					
+					decoder.DecodeBlock(
+						buffer.Slice(
+							blockIndex * decoder.GetBlockSize(format),
+							decoder.GetBlockSize(format)
+							),
+						format,
+						decoded.AsSpan2D().Slice(y, x, 4, 4));
+					blockIndex++;
+				}
+			}
+
+			colors.TryGetSpan(out var oPixels);
+			decoded.AsSpan2D().TryGetSpan(out var dPixels);
+			var psnr = ImageQuality.PeakSignalToNoiseRatio(oPixels, dPixels,
+				format != CompressionFormat.Bc1);
+
+			TestHelper.AssertPSNR(psnr, quality);
+		}
+	}
+}

--- a/BCnEncTests/Support/ImageLoader.cs
+++ b/BCnEncTests/Support/ImageLoader.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 

--- a/BCnEncTests/Support/TestHelper.cs
+++ b/BCnEncTests/Support/TestHelper.cs
@@ -169,7 +169,7 @@ namespace BCnEncTests.Support
 				MemoryMarshal.Cast<Rgba32, ColorRgba32>(pixels2));
 		}
 
-		private static void AssertPSNR(float psnr, CompressionQuality quality)
+		public static void AssertPSNR(float psnr, CompressionQuality quality)
 		{
 			if (quality == CompressionQuality.Fast)
 			{

--- a/BCnEncTests/Support/TestHelper.cs
+++ b/BCnEncTests/Support/TestHelper.cs
@@ -131,7 +131,10 @@ namespace BCnEncTests.Support
 		{
 			using var fs = File.OpenRead(filename);
 			var ktx = KtxFile.Load(fs);
-			var decoder = new BcDecoder();
+			var decoder = new BcDecoder()
+			{
+				OutputOptions = { Bc4Component = Bc4Component.Luminance }
+			};
 			using var img = decoder.DecodeToImageRgba32(ktx);
 
 			return CalculatePSNR(original, img);

--- a/BCnEncTests/Support/TestHelper.cs
+++ b/BCnEncTests/Support/TestHelper.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
 using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;

--- a/BCnEncTests/Support/TestHelper.cs
+++ b/BCnEncTests/Support/TestHelper.cs
@@ -27,9 +27,9 @@ namespace BCnEncTests.Support
 			AssertPSNR(psnr, quality);
 		}
 
-		public static void AssertImagesEqual(Image<Rgba32> original, Image<Rgba32> image, CompressionQuality quality)
+		public static void AssertImagesEqual(Image<Rgba32> original, Image<Rgba32> image, CompressionQuality quality, bool countAlpha = true)
 		{
-			var psnr = CalculatePSNR(original, image);
+			var psnr = CalculatePSNR(original, image, countAlpha);
 			AssertPSNR(psnr, quality);
 		}
 
@@ -153,7 +153,7 @@ namespace BCnEncTests.Support
 			AssertPSNR(psnr, encoder.OutputOptions.Quality);
 		}
 
-		private static float CalculatePSNR(Image<Rgba32> original, Image<Rgba32> decoded)
+		private static float CalculatePSNR(Image<Rgba32> original, Image<Rgba32> decoded, bool countAlpha = true)
 		{
 			if (!original.TryGetSinglePixelSpan(out var pixels))
 			{
@@ -166,7 +166,7 @@ namespace BCnEncTests.Support
 			
 			return ImageQuality.PeakSignalToNoiseRatio(
 				MemoryMarshal.Cast<Rgba32, ColorRgba32>(pixels),
-				MemoryMarshal.Cast<Rgba32, ColorRgba32>(pixels2));
+				MemoryMarshal.Cast<Rgba32, ColorRgba32>(pixels2), countAlpha);
 		}
 
 		public static void AssertPSNR(float psnr, CompressionQuality quality)

--- a/BCnEncoder.NET.ImageSharp/BCnDecoderExtensions.cs
+++ b/BCnEncoder.NET.ImageSharp/BCnDecoderExtensions.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BCnEncoder.Decoder;
+using BCnEncoder.Shared;
+using BCnEncoder.Shared.ImageFiles;
+using Microsoft.Toolkit.HighPerformance.Extensions;
+using Microsoft.Toolkit.HighPerformance.Memory;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace BCnEncoder.NET.ImageSharp
+{
+	public static class BCnDecoderExtensions
+	{
+
+		/// <summary>
+		/// Decode raw encoded image data.
+		/// </summary>
+		/// <param name="inputStream">The stream containing the encoded data.</param>
+		/// <param name="pixelWidth">The pixelWidth of the image.</param>
+		/// <param name="pixelHeight">The pixelHeight of the image.</param>
+		/// <param name="format">The Format the encoded data is in.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static Image<Rgba32> DecodeRawToImageRgba32(this BcDecoder decoder, Stream inputStream, int pixelWidth, int pixelHeight, CompressionFormat format)
+		{
+			return ColorMemoryToImage(decoder.DecodeRaw2D(inputStream, pixelWidth, pixelHeight, format));
+		}
+
+		/// <summary>
+		/// Decode raw encoded image data.
+		/// </summary>
+		/// <param name="input">The array containing the encoded data.</param>
+		/// <param name="pixelWidth">The pixelWidth of the image.</param>
+		/// <param name="pixelHeight">The pixelHeight of the image.</param>
+		/// <param name="format">The Format the encoded data is in.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static Image<Rgba32> DecodeRawToImageRgba32(this BcDecoder decoder, byte[] input, int pixelWidth, int pixelHeight, CompressionFormat format)
+		{
+			return ColorMemoryToImage(decoder.DecodeRaw2D(input, pixelWidth, pixelHeight, format));
+		}
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="inputStream">The stream that contains either ktx or dds file.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static Image<Rgba32> DecodeToImageRgba32(this BcDecoder decoder, Stream inputStream)
+		{
+			return ColorMemoryToImage(decoder.Decode2D(inputStream));
+		}
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="inputStream">The stream that contains either ktx or dds file.</param>
+		/// <returns>An array of decoded Rgba32 images.</returns>
+		public static Image<Rgba32>[] DecodeAllMipMapsToImageRgba32(this BcDecoder decoder, Stream inputStream)
+		{
+			var decoded = decoder.DecodeAllMipMaps2D(inputStream);
+			var output = new Image<Rgba32>[decoded.Length];
+			for (var i = 0; i < decoded.Length; i++)
+			{
+				output[i] = ColorMemoryToImage(decoded[i]);
+			}
+			return output;
+		}
+
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Ktx file.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static Image<Rgba32> DecodeToImageRgba32(this BcDecoder decoder, KtxFile file)
+		{
+			return ColorMemoryToImage(decoder.Decode2D(file));
+		}
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Ktx file.</param>
+		/// <returns>An array of decoded Rgba32 images.</returns>
+		public static Image<Rgba32>[] DecodeAllMipMapsToImageRgba32(this BcDecoder decoder, KtxFile file)
+		{
+			var decoded = decoder.DecodeAllMipMaps2D(file);
+			var output = new Image<Rgba32>[decoded.Length];
+			for (var i = 0; i < decoded.Length; i++)
+			{
+				output[i] = ColorMemoryToImage(decoded[i]);
+			}
+			return output;
+		}
+
+		/// <summary>
+		/// Read a Dds file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Dds file.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static Image<Rgba32> DecodeToImageRgba32(this BcDecoder decoder, DdsFile file)
+		{
+			return ColorMemoryToImage(decoder.Decode2D(file));
+		}
+
+		/// <summary>
+		/// Read a Dds file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Dds file.</param>
+		/// <returns>An array of decoded Rgba32 images.</returns>
+		public static Image<Rgba32>[] DecodeAllMipMapsToImageRgba32(this BcDecoder decoder, DdsFile file)
+		{
+			var decoded = decoder.DecodeAllMipMaps2D(file);
+			var output = new Image<Rgba32>[decoded.Length];
+			for (var i = 0; i < decoded.Length; i++)
+			{
+				output[i] = ColorMemoryToImage(decoded[i]);
+			}
+			return output;
+		}
+
+
+
+		/// <summary>
+		/// Decode raw encoded image data.
+		/// </summary>
+		/// <param name="inputStream">The stream containing the encoded data.</param>
+		/// <param name="pixelWidth">The pixelWidth of the image.</param>
+		/// <param name="pixelHeight">The pixelHeight of the image.</param>
+		/// <param name="format">The Format the encoded data is in.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static async Task<Image<Rgba32>> DecodeRawToImageRgba32Async(this BcDecoder decoder, Stream inputStream, int pixelWidth, int pixelHeight, CompressionFormat format, CancellationToken token = default)
+		{
+			return ColorMemoryToImage(await decoder.DecodeRaw2DAsync(inputStream, pixelWidth, pixelHeight, format, token));
+		}
+
+		/// <summary>
+		/// Decode raw encoded image data.
+		/// </summary>
+		/// <param name="input">The array containing the encoded data.</param>
+		/// <param name="pixelWidth">The pixelWidth of the image.</param>
+		/// <param name="pixelHeight">The pixelHeight of the image.</param>
+		/// <param name="format">The Format the encoded data is in.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static async Task<Image<Rgba32>> DecodeRawToImageRgba32Async(this BcDecoder decoder, byte[] input, int pixelWidth, int pixelHeight, CompressionFormat format, CancellationToken token = default)
+		{
+			return ColorMemoryToImage(await decoder.DecodeRaw2DAsync(input, pixelWidth, pixelHeight, format, token));
+		}
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="inputStream">The stream that contains either ktx or dds file.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static async Task<Image<Rgba32>> DecodeToImageRgba32Async(this BcDecoder decoder, Stream inputStream, CancellationToken token = default)
+		{
+			return ColorMemoryToImage(await decoder.Decode2DAsync(inputStream, token));
+		}
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="inputStream">The stream that contains either ktx or dds file.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>An array of decoded Rgba32 images.</returns>
+		public static async Task<Image<Rgba32>[]> DecodeAllMipMapsToImageRgba32Async(this BcDecoder decoder, Stream inputStream, CancellationToken token = default)
+		{
+			var decoded = await decoder.DecodeAllMipMaps2DAsync(inputStream, token);
+			var output = new Image<Rgba32>[decoded.Length];
+			for (var i = 0; i < decoded.Length; i++)
+			{
+				output[i] = ColorMemoryToImage(decoded[i]);
+			}
+			return output;
+		}
+
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Ktx file.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static async Task<Image<Rgba32>> DecodeToImageRgba32Async(this BcDecoder decoder, KtxFile file, CancellationToken token = default)
+		{
+			return ColorMemoryToImage(await decoder.Decode2DAsync(file, token));
+		}
+
+		/// <summary>
+		/// Read a Ktx file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Ktx file.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>An array of decoded Rgba32 images.</returns>
+		public static async Task<Image<Rgba32>[]> DecodeAllMipMapsToImageRgba32Async(this BcDecoder decoder, KtxFile file, CancellationToken token = default)
+		{
+			var decoded = await decoder.DecodeAllMipMaps2DAsync(file, token);
+			var output = new Image<Rgba32>[decoded.Length];
+			for (var i = 0; i < decoded.Length; i++)
+			{
+				output[i] = ColorMemoryToImage(decoded[i]);
+			}
+			return output;
+		}
+
+		/// <summary>
+		/// Read a Dds file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Dds file.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>The decoded Rgba32 image.</returns>
+		public static async Task<Image<Rgba32>> DecodeToImageRgba32Async(this BcDecoder decoder, DdsFile file, CancellationToken token = default)
+		{
+			return ColorMemoryToImage(await decoder.Decode2DAsync(file, token));
+		}
+
+		/// <summary>
+		/// Read a Dds file and decode it.
+		/// </summary>
+		/// <param name="file">The loaded Dds file.</param>
+		/// <param name="token">The cancellation token for this asynchronous operation.</param>
+		/// <returns>An array of decoded Rgba32 images.</returns>
+		public static async Task<Image<Rgba32>[]> DecodeAllMipMapsToImageRgba32Async(this BcDecoder decoder, DdsFile file, CancellationToken token = default)
+		{
+			var decoded = await decoder.DecodeAllMipMaps2DAsync(file, token);
+			var output = new Image<Rgba32>[decoded.Length];
+			for (var i = 0; i < decoded.Length; i++)
+			{
+				output[i] = ColorMemoryToImage(decoded[i]);
+			}
+			return output;
+		}
+
+
+
+		private static Image<Rgba32> ColorMemoryToImage(Memory2D<ColorRgba32> colors)
+		{
+			var output = new Image<Rgba32>(colors.Width, colors.Height);
+			output.TryGetSinglePixelSpan(out var pixels);
+			colors.Span.TryGetSpan(out var decodedPixels);
+
+			for (int i = 0; i < pixels.Length; i++)
+			{
+				var c = decodedPixels[i];
+				pixels[i] = new Rgba32(c.r, c.g, c.b, c.a);
+			}
+			return output;
+		}
+	}
+}

--- a/BCnEncoder.NET.ImageSharp/BCnDecoderExtensions.cs
+++ b/BCnEncoder.NET.ImageSharp/BCnDecoderExtensions.cs
@@ -247,7 +247,7 @@ namespace BCnEncoder.NET.ImageSharp
 			output.TryGetSinglePixelSpan(out var pixels);
 			colors.Span.TryGetSpan(out var decodedPixels);
 
-			for (int i = 0; i < pixels.Length; i++)
+			for (var i = 0; i < pixels.Length; i++)
 			{
 				var c = decodedPixels[i];
 				pixels[i] = new Rgba32(c.r, c.g, c.b, c.a);


### PR DESCRIPTION
This PR removes ImageSharp completely as a dependency to BCnEncoder, in preparation for version 2.0.