### PR TITLE
Adding support for BGR, BGR565, BGRA4444 and BGRA5551

### DIFF
--- a/BCnEnc.Net/Decoder/BcDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcDecoder.cs
@@ -1557,6 +1557,10 @@ namespace BCnEncoder.Decoder
 				case CompressionFormat.Rgb:
 				case CompressionFormat.Rgba:
 				case CompressionFormat.Bgra:
+				case CompressionFormat.Bgr:
+				case CompressionFormat.B5G6R5:
+				case CompressionFormat.B5G5R5A1:
+				case CompressionFormat.B4G4R4A4:
 					return true;
 
 				default:
@@ -1670,6 +1674,18 @@ namespace BCnEncoder.Decoder
 				case CompressionFormat.Rgba:
 					return new RawRgbaDecoder();
 
+				case CompressionFormat.B4G4R4A4:
+					return new RawB4G4R4A4Decoder();
+
+				case CompressionFormat.B5G5R5A1:
+					return new RawB5G5R5A1Decoder();
+
+				case CompressionFormat.B5G6R5:
+					return new RawB5G6R5Decoder();
+
+				case CompressionFormat.Bgr:
+					return new RawBgrDecoder();
+
 				case CompressionFormat.Bgra:
 					return new RawBgraDecoder();
 
@@ -1736,6 +1752,12 @@ namespace BCnEncoder.Decoder
 				case CompressionFormat.Rgba:
 					return 4;
 
+				case CompressionFormat.B4G4R4A4:
+				case CompressionFormat.B5G5R5A1:
+				case CompressionFormat.B5G6R5:
+					return 2;
+
+				case CompressionFormat.Bgr:
 				case CompressionFormat.Bgra:
 					return 4;
 
@@ -1863,6 +1885,18 @@ namespace BCnEncoder.Decoder
 				case DxgiFormat.DxgiFormatR8G8B8A8Unorm:
 					return CompressionFormat.Rgba;
 
+				case DxgiFormat.DxgiFormatB4G4R4A4Unorm:
+					return CompressionFormat.B4G4R4A4;
+
+				case DxgiFormat.DxgiFormatB5G5R5A1Unorm:
+					return CompressionFormat.B5G5R5A1;
+
+				case DxgiFormat.DxgiFormatB5G6R5Unorm:
+					return CompressionFormat.B5G6R5;
+
+				case DxgiFormat.DxgiFormatB8G8R8X8Unorm:
+					return CompressionFormat.Bgr;
+
 				case DxgiFormat.DxgiFormatB8G8R8A8Unorm:
 					return CompressionFormat.Bgra;
 
@@ -1931,6 +1965,9 @@ namespace BCnEncoder.Decoder
 					return pixelWidth * pixelHeight;
 
 				case CompressionFormat.Rg:
+				case CompressionFormat.B5G6R5:
+				case CompressionFormat.B5G5R5A1:
+				case CompressionFormat.B4G4R4A4:
 					return 2 * pixelWidth * pixelHeight;
 
 				case CompressionFormat.Rgb:
@@ -1938,6 +1975,7 @@ namespace BCnEncoder.Decoder
 
 				case CompressionFormat.Rgba:
 				case CompressionFormat.Bgra:
+				case CompressionFormat.Bgr:
 					return 4 * pixelWidth * pixelHeight;
 
 				case CompressionFormat.Bc1:

--- a/BCnEnc.Net/Decoder/RawDecoder.cs
+++ b/BCnEnc.Net/Decoder/RawDecoder.cs
@@ -1,5 +1,7 @@
-using System;
 using BCnEncoder.Shared;
+
+using System;
+using System.Runtime.InteropServices;
 
 namespace BCnEncoder.Decoder
 {
@@ -188,4 +190,125 @@ namespace BCnEncoder.Decoder
 			return output;
 		}
 	}
+
+	/// <summary>
+	/// A class to decode data to BGRX components.
+	/// </summary>
+	public class RawBgrDecoder : IRawDecoder
+	{
+		/// <summary>
+		/// Decode the data to color components.
+		/// </summary>
+		/// <param name="data">The data to decode.</param>
+		/// <param name="context">The context of the current operation.</param>
+		/// <returns>The decoded color components.</returns>
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
+		{
+			var output = new ColorRgba32[data.Length / 4];
+
+			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
+
+			var span = data.Span;
+			for (var i = 0; i < output.Length; i++)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+
+				output[i].b = span[i * 4];
+				output[i].g = span[i * 4 + 1];
+				output[i].r = span[i * 4 + 2];
+				output[i].a = 255;
+			}
+
+			return output;
+		}
+	}
+
+	/// <summary>
+	/// A class to decode data to B4G4R4A4 components.
+	/// </summary>
+	public class RawB4G4R4A4Decoder : IRawDecoder
+	{
+		/// <summary>
+		/// Decode the data to color components.
+		/// </summary>
+		/// <param name="data">The data to decode.</param>
+		/// <param name="context">The context of the current operation.</param>
+		/// <returns>The decoded color components.</returns>
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
+		{
+			var output = new ColorRgba32[data.Length / 2];
+
+			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
+
+			var span = MemoryMarshal.Cast<byte, ushort>(data.Span);
+			for (var i = 0; i < output.Length; i++)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+
+				var color4444 = new ColorRgb4444(span[i]);
+				output[i] = new ColorRgba32(color4444.R, color4444.G, color4444.B, color4444.A);
+			}
+			return output;
+		}
+	}
+
+	/// <summary>
+	/// A class to decode data to B5G5R5A1 components.
+	/// </summary>
+	public class RawB5G5R5A1Decoder : IRawDecoder
+	{
+		/// <summary>
+		/// Decode the data to color components.
+		/// </summary>
+		/// <param name="data">The data to decode.</param>
+		/// <param name="context">The context of the current operation.</param>
+		/// <returns>The decoded color components.</returns>
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
+		{
+			var output = new ColorRgba32[data.Length / 2];
+
+			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
+
+			var span = MemoryMarshal.Cast<byte, ushort>(data.Span);
+			for (var i = 0; i < output.Length; i++)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+
+				var color5551 = new ColorRgb555(span[i]);
+				output[i] = new ColorRgba32(color5551.R, color5551.G, color5551.B, color5551.Mode == 0 ? (byte)0 : (byte)255);
+			}
+			return output;
+		}
+	}
+
+	/// <summary>
+	/// A class to decode data to B5G6R5 components.
+	/// </summary>
+	public class RawB5G6R5Decoder : IRawDecoder
+	{
+		/// <summary>
+		/// Decode the data to color components.
+		/// </summary>
+		/// <param name="data">The data to decode.</param>
+		/// <param name="context">The context of the current operation.</param>
+		/// <returns>The decoded color components.</returns>
+		public ColorRgba32[] Decode(ReadOnlyMemory<byte> data, OperationContext context)
+		{
+			var output = new ColorRgba32[data.Length / 2];
+
+			// HINT: Ignoring parallel execution since we wouldn't gain performance from it.
+
+			var span = MemoryMarshal.Cast<byte, ushort>(data.Span);
+			for (var i = 0; i < output.Length; i++)
+			{
+				context.CancellationToken.ThrowIfCancellationRequested();
+
+				var color56 = new ColorRgb565(span[i]);
+				output[i] = color56.ToColorRgba32();
+			}
+			return output;
+		}
+	}
+
+
 }

--- a/BCnEnc.Net/Shared/Colors.cs
+++ b/BCnEnc.Net/Shared/Colors.cs
@@ -597,6 +597,196 @@ namespace BCnEncoder.Shared
 		}
 	}
 
+	internal struct ColorRgb4444 : IEquatable<ColorRgb4444>
+	{
+		public bool Equals(ColorRgb4444 other)
+		{
+			return data == other.data;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is ColorRgb4444 other && Equals(other);
+		}
+
+		public override int GetHashCode()
+		{
+			return data.GetHashCode();
+		}
+
+		public static bool operator ==(ColorRgb4444 left, ColorRgb4444 right)
+		{
+			return left.Equals(right);
+		}
+
+		public static bool operator !=(ColorRgb4444 left, ColorRgb4444 right)
+		{
+			return !left.Equals(right);
+		}
+
+		private const ushort AlphaMask = 0b1111_0000_0000_0000;
+		private const int AlphaShift = 12;
+		private const ushort RedMask = 0b0000_1111_0000_0000;
+		private const int RedShift = 8;
+		private const ushort GreenMask = 0b0000_0000_1111_0000;
+		private const int GreenShift = 4;
+		private const ushort BlueMask = 0b0000_0000_0000_1111;
+
+		public ushort data;
+
+		public byte A
+		{
+			readonly get
+			{
+				var a4 = (data & AlphaMask) >> AlphaShift;
+				return (byte)((a4 << 4) | (a4 >> 0));
+			}
+			set
+			{
+				var a4 = value;
+				data = (ushort)(data & ~AlphaMask);
+				data = (ushort)(data | (a4 << AlphaShift));
+			}
+		}
+
+		public byte R
+		{
+			readonly get
+			{
+				var r4 = (data & RedMask) >> RedShift;
+				return (byte)((r4 << 4) | (r4 >> 0));
+			}
+			set
+			{
+				var r4 = value >> 3;
+				data = (ushort)(data & ~RedMask);
+				data = (ushort)(data | (r4 << RedShift));
+			}
+		}
+
+		public byte G
+		{
+			readonly get
+			{
+				var g4 = (data & GreenMask) >> GreenShift;
+				return (byte)((g4 << 4) | (g4 >> 0));
+			}
+			set
+			{
+				var g4 = value >> 3;
+				data = (ushort)(data & ~GreenMask);
+				data = (ushort)(data | (g4 << GreenShift));
+			}
+		}
+
+		public byte B
+		{
+			readonly get
+			{
+				var b4 = data & BlueMask;
+				return (byte)((b4 << 4) | (b4 >> 0));
+			}
+			set
+			{
+				var b4 = value >> 3;
+				data = (ushort)(data & ~BlueMask);
+				data = (ushort)(data | b4);
+			}
+		}
+
+		public int RawA
+		{
+			readonly get => (data & AlphaMask) >> AlphaShift;
+			set
+			{
+				if (value > 15) value = 15;
+				if (value < 0) value = 0;
+				data = (ushort)(data & ~AlphaMask);
+				data = (ushort)(data | (value << AlphaShift));
+			}
+		}
+
+		public int RawR
+		{
+			readonly get => (data & RedMask) >> RedShift;
+			set
+			{
+				if (value > 15) value = 15;
+				if (value < 0) value = 0;
+				data = (ushort)(data & ~RedMask);
+				data = (ushort)(data | (value << RedShift));
+			}
+		}
+
+		public int RawG
+		{
+			readonly get => (data & GreenMask) >> GreenShift;
+			set
+			{
+				if (value > 15) value = 15;
+				if (value < 0) value = 0;
+				data = (ushort)(data & ~GreenMask);
+				data = (ushort)(data | (value << GreenShift));
+			}
+		}
+
+		public int RawB
+		{
+			readonly get => data & BlueMask;
+			set
+			{
+				if (value > 15) value = 15;
+				if (value < 0) value = 0;
+				data = (ushort)(data & ~BlueMask);
+				data = (ushort)(data | value);
+			}
+		}
+
+		public ColorRgb4444(ushort value)
+		{
+			data = value;
+		}
+
+		public ColorRgb4444(byte r, byte g, byte b)
+		{
+			data = 0;
+			R = r;
+			G = g;
+			B = b;
+		}
+
+		public ColorRgb4444(Vector3 colorVector)
+		{
+			data = 0;
+			R = ByteHelper.ClampToByte(colorVector.X * 255);
+			G = ByteHelper.ClampToByte(colorVector.Y * 255);
+			B = ByteHelper.ClampToByte(colorVector.Z * 255);
+		}
+
+		public ColorRgb4444(ColorRgb24 color)
+		{
+			data = 0;
+			R = color.r;
+			G = color.g;
+			B = color.b;
+		}
+
+		public readonly ColorRgb24 ToColorRgb24()
+		{
+			return new ColorRgb24(R, G, B);
+		}
+
+		public override string ToString()
+		{
+			return $"r : {R} g : {G} b : {B} a : {A}";
+		}
+
+		public ColorRgba32 ToColorRgba32()
+		{
+			return new ColorRgba32(R, G, B, A);
+		}
+	}
+
 	internal struct ColorRgb555 : IEquatable<ColorRgb555>
 	{
 		public bool Equals(ColorRgb555 other)
@@ -728,6 +918,11 @@ namespace BCnEncoder.Shared
 				data = (ushort)(data & ~BlueMask);
 				data = (ushort)(data | value);
 			}
+		}
+
+		public ColorRgb555(ushort value)
+		{
+			data = value;
 		}
 
 		public ColorRgb555(byte r, byte g, byte b)
@@ -884,6 +1079,11 @@ namespace BCnEncoder.Shared
 				data = (ushort)(data & ~BlueMask);
 				data = (ushort)(data | value);
 			}
+		}
+
+		public ColorRgb565(ushort value)
+		{
+			data = value;
 		}
 
 		public ColorRgb565(byte r, byte g, byte b)

--- a/BCnEnc.Net/Shared/CompressionFormat.cs
+++ b/BCnEnc.Net/Shared/CompressionFormat.cs
@@ -1,55 +1,77 @@
 namespace BCnEncoder.Shared
 {
-    public enum CompressionFormat
-    {
-        /// <summary>
-        /// Raw unsigned byte 8-bit Luminance data
-        /// </summary>
-        R,
-        /// <summary>
-        /// Raw unsigned byte 16-bit RG data
-        /// </summary>
-        Rg,
-        /// <summary>
-        /// Raw unsigned byte 24-bit RGB data
-        /// </summary>
-        Rgb,
-        /// <summary>
-        /// Raw unsigned byte 32-bit RGBA data
-        /// </summary>
-        Rgba,
+	public enum CompressionFormat
+	{
+		/// <summary>
+		/// Raw unsigned byte 8-bit Luminance data
+		/// </summary>
+		R,
+		/// <summary>
+		/// Raw unsigned byte 16-bit RG data
+		/// </summary>
+		Rg,
+		/// <summary>
+		/// Raw unsigned byte 24-bit RGB data
+		/// </summary>
+		Rgb,
+		/// <summary>
+		/// Raw unsigned byte 32-bit RGBA data
+		/// </summary>
+		Rgba,
+
+		/// <summary>
+		/// Raw unsigned byte 16-bit B4G4R4A4 data
+		/// </summary>
+		B4G4R4A4,
+
+		/// <summary>
+		/// Raw unsigned byte 16-bit B5G6R5 data
+		/// </summary>
+		B5G6R5,
+
+		/// <summary>
+		/// Raw unsigned byte 16-bit B5G5R5A1 data
+		/// </summary>
+		B5G5R5A1,
+
+		/// <summary>
+		/// Raw unsigned byte 32-bit BGRX data
+		/// </summary>
+		Bgr,
+
 		/// <summary>
 		/// Raw unsigned byte 32-bit BGRA data
 		/// </summary>
 		Bgra,
+
 		/// <summary>
 		/// BC1 / DXT1 with no alpha. Very widely supported and good compression ratio.
 		/// </summary>
 		Bc1,
-        /// <summary>
-        /// BC1 / DXT1 with 1-bit of alpha.
-        /// </summary>
-        Bc1WithAlpha,
-        /// <summary>
-        /// BC2 / DXT3 encoding with alpha. Good for sharp alpha transitions.
-        /// </summary>
-        Bc2,
-        /// <summary>
-        /// BC3 / DXT5 encoding with alpha. Good for smooth alpha transitions.
-        /// </summary>
-        Bc3,
-        /// <summary>
-        /// BC4 single-channel encoding. Only luminance is encoded.
-        /// </summary>
-        Bc4,
-        /// <summary>
-        /// BC5 dual-channel encoding. Only red and green channels are encoded.
-        /// </summary>
-        Bc5,
-        /// <summary>
-        /// BC6H / BPTC unsigned float encoding. Can compress HDR textures without alpha. Does not support negative values.
-        /// </summary>
-        Bc6U,
+		/// <summary>
+		/// BC1 / DXT1 with 1-bit of alpha.
+		/// </summary>
+		Bc1WithAlpha,
+		/// <summary>
+		/// BC2 / DXT3 encoding with alpha. Good for sharp alpha transitions.
+		/// </summary>
+		Bc2,
+		/// <summary>
+		/// BC3 / DXT5 encoding with alpha. Good for smooth alpha transitions.
+		/// </summary>
+		Bc3,
+		/// <summary>
+		/// BC4 single-channel encoding. Only luminance is encoded.
+		/// </summary>
+		Bc4,
+		/// <summary>
+		/// BC5 dual-channel encoding. Only red and green channels are encoded.
+		/// </summary>
+		Bc5,
+		/// <summary>
+		/// BC6H / BPTC unsigned float encoding. Can compress HDR textures without alpha. Does not support negative values.
+		/// </summary>
+		Bc6U,
 		/// <summary>
 		/// BC6H / BPTC signed float encoding. Can compress HDR textures without alpha. Supports negative values.
 		/// </summary>
@@ -73,26 +95,30 @@ namespace BCnEncoder.Shared
 		/// <summary>
 		/// Unknown format
 		/// </summary>
-		Unknown
+		Unknown,
 	}
 
-    public static class CompressionFormatExtensions
-    {
-        public static bool IsCompressedFormat(this CompressionFormat format)
-        {
-            switch (format)
-            {
-                case CompressionFormat.R:
-                case CompressionFormat.Rg:
-                case CompressionFormat.Rgb:
-                case CompressionFormat.Rgba:
+	public static class CompressionFormatExtensions
+	{
+		public static bool IsCompressedFormat(this CompressionFormat format)
+		{
+			switch (format)
+			{
+				case CompressionFormat.R:
+				case CompressionFormat.Rg:
+				case CompressionFormat.Rgb:
+				case CompressionFormat.Rgba:
+				case CompressionFormat.B5G6R5:
+				case CompressionFormat.B4G4R4A4:
+				case CompressionFormat.B5G5R5A1:
+				case CompressionFormat.Bgr:
 				case CompressionFormat.Bgra:
-                    return false;
+					return false;
 
-                default:
-                    return true;
-            }
-        }
+				default:
+					return true;
+			}
+		}
 
 		public static bool IsHdrFormat(this CompressionFormat format)
 		{

--- a/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
+++ b/BCnEnc.Net/Shared/ImageFiles/DdsFile.cs
@@ -486,6 +486,24 @@ namespace BCnEncoder.Shared.ImageFiles
 									return DxgiFormat.DxgiFormatB8G8R8A8Unorm;
 								}
 							}
+							else if (dwRgbBitCount == 16)
+							{
+								if (dwRBitMask == 0b0_11111_00000_00000 &&
+									dwGBitMask == 0b0_00000_11111_00000 &&
+									dwBBitMask == 0b0_00000_00000_11111 &&
+									dwABitMask == 0b1_00000_00000_00000)
+								{
+									return DxgiFormat.DxgiFormatB5G5R5A1Unorm;
+								}
+
+								if (dwRBitMask == 0b0000_1111_0000_0000 &&
+									dwGBitMask == 0b0000_0000_1111_0000 &&
+									dwBBitMask == 0b0000_0000_0000_1111 &&
+									dwABitMask == 0b1111_0000_0000_0000)
+								{
+									return DxgiFormat.DxgiFormatB4G4R4A4Unorm;
+								}
+							}
 						}
 						else //RGB
 						{
@@ -494,6 +512,25 @@ namespace BCnEncoder.Shared.ImageFiles
 								if (dwRBitMask == 0xff0000 && dwGBitMask == 0xff00 && dwBBitMask == 0xff)
 								{
 									return DxgiFormat.DxgiFormatB8G8R8X8Unorm;
+								}
+							}
+							else if (dwRgbBitCount == 16)
+							{
+								if (dwRBitMask == 0b0_11111_00000_00000 &&
+									dwGBitMask == 0b0_00000_11111_00000 &&
+									dwBBitMask == 0b0_00000_00000_11111)
+								{
+									// B5G5R5A1 without DdpfAlphaPixels and dwABitMask = 0.
+									// There is no DxgiFormat that matches.
+									// Visual Studio reports it as B5G5R5A1
+									return DxgiFormat.DxgiFormatB5G5R5A1Unorm;
+								}
+
+								if (dwRBitMask == 0b11111_000000_00000 &&
+								    dwGBitMask == 0b00000_111111_00000 &&
+								    dwBBitMask == 0b00000_000000_11111)
+								{
+									return DxgiFormat.DxgiFormatB5G6R5Unorm;
 								}
 							}
 						}


### PR DESCRIPTION
I added support for a bunch of BGR/A formats that I need for a project of mine. I'll try to add encoders and tests for this as well but the sample images are not under public domain, so I'll need to encode my own.

There is one rather weird case where I have an image that uses B5G5R5 but has no DdpfAlphaPixels flag and dwABitMask = 0. I'm not exactly sure how to go about this. Visual Studio detects this as B5G5R5A1. I'm doing the same but right now this results in a completely transparent image since the RawDecoder is missing context for this.