### PR TITLE
Migrate to `CommunityToolkit.HighPerformance`

### DIFF
--- a/BCnEnc.Net/BCnEncoder.csproj
+++ b/BCnEnc.Net/BCnEncoder.csproj
@@ -47,7 +47,7 @@ Supported formats are:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/BCnEnc.Net/Decoder/BcDecoder.cs
+++ b/BCnEnc.Net/Decoder/BcDecoder.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BCnEncoder.Shared.ImageFiles;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 
 namespace BCnEncoder.Decoder
 {

--- a/BCnEnc.Net/Encoder/BcEncoder.cs
+++ b/BCnEnc.Net/Encoder/BcEncoder.cs
@@ -8,7 +8,7 @@ using BCnEncoder.Encoder.Bptc;
 using BCnEncoder.Encoder.Options;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 
 namespace BCnEncoder.Encoder
 {

--- a/BCnEnc.Net/Shared/HdrImage.cs
+++ b/BCnEnc.Net/Shared/HdrImage.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 
 namespace BCnEncoder.Shared
 {

--- a/BCnEnc.Net/Shared/ImageToBlocks.cs
+++ b/BCnEnc.Net/Shared/ImageToBlocks.cs
@@ -1,4 +1,4 @@
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 
 namespace BCnEncoder.Shared
 {

--- a/BCnEnc.Net/Shared/MipMapper.cs
+++ b/BCnEnc.Net/Shared/MipMapper.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 
 namespace BCnEncoder.Shared
 {

--- a/BCnEncTests/Bc6EncoderTests.cs
+++ b/BCnEncTests/Bc6EncoderTests.cs
@@ -7,7 +7,7 @@ using BCnEncoder.Encoder;
 using BCnEncoder.Encoder.Bptc;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/BCnEncTests/Bc6HDecoderTests.cs
+++ b/BCnEncTests/Bc6HDecoderTests.cs
@@ -8,7 +8,7 @@ using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;

--- a/BCnEncTests/BlockTests.cs
+++ b/BCnEncTests/BlockTests.cs
@@ -1,6 +1,6 @@
 using System;
 using BCnEncoder.Shared;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;

--- a/BCnEncTests/Examples.cs
+++ b/BCnEncTests/Examples.cs
@@ -6,7 +6,7 @@ using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
 using BCnEncoder.ImageSharp;
 using BCnEncoder.Shared;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;

--- a/BCnEncTests/SingleBlockTests.cs
+++ b/BCnEncTests/SingleBlockTests.cs
@@ -7,7 +7,7 @@ using BCnEncoder.Decoder;
 using BCnEncoder.Encoder;
 using BCnEncoder.Shared;
 using BCnEncTests.Support;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;

--- a/BCnEncTests/Support/TestHelper.cs
+++ b/BCnEncTests/Support/TestHelper.cs
@@ -8,7 +8,7 @@ using BCnEncoder.Encoder;
 using BCnEncoder.ImageSharp;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Xunit;

--- a/BCnEncoder.NET.ImageSharp/BCnDecoderExtensions.cs
+++ b/BCnEncoder.NET.ImageSharp/BCnDecoderExtensions.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using BCnEncoder.Decoder;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;

--- a/BCnEncoder.NET.ImageSharp/BCnEncoder.NET.ImageSharp.csproj
+++ b/BCnEncoder.NET.ImageSharp/BCnEncoder.NET.ImageSharp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -27,7 +27,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BCnEncoder.NET.ImageSharp/BCnEncoderExtensions.cs
+++ b/BCnEncoder.NET.ImageSharp/BCnEncoderExtensions.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using BCnEncoder.Encoder;
 using BCnEncoder.Shared;
 using BCnEncoder.Shared.ImageFiles;
-using Microsoft.Toolkit.HighPerformance;
+using CommunityToolkit.HighPerformance;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;


### PR DESCRIPTION
This PR replaces the deprecated `Microsoft.Toolkit.HighPerformance` with the new `CommunityToolkit.HighPerformance` package.

Resolves: https://github.com/Nominom/BCnEncoder.NET/issues/60